### PR TITLE
refactor(api): improve vehicle display name handling in TelegramService

### DIFF
--- a/apps/api/src/app/telegram/telegram.service.spec.ts
+++ b/apps/api/src/app/telegram/telegram.service.spec.ts
@@ -94,6 +94,10 @@ describe('TelegramService', () => {
         'user-123',
         expect.stringContaining('TEST123456')
       );
+      expect(telegramBotService.sendMessageToUser).not.toHaveBeenCalledWith(
+        'user-123',
+        expect.stringContaining('(TEST123456)')
+      );
     });
 
     it('should send alert in French with display name', async () => {
@@ -120,7 +124,11 @@ describe('TelegramService', () => {
       );
       expect(telegramBotService.sendMessageToUser).toHaveBeenCalledWith(
         'user-123',
-        expect.stringContaining('Mon Tesla (TEST123456)')
+        expect.stringContaining('Mon Tesla')
+      );
+      expect(telegramBotService.sendMessageToUser).not.toHaveBeenCalledWith(
+        'user-123',
+        expect.stringContaining('TEST123456')
       );
     });
 

--- a/apps/api/src/app/telegram/telegram.service.ts
+++ b/apps/api/src/app/telegram/telegram.service.ts
@@ -78,7 +78,7 @@ export class TelegramService {
     return `
 🚨 <b>${i18n.t('TESLA SENTRY ALERT', { lng })}</b> 🚨
 
-🚗 <b>${i18n.t('Vehicle', { lng })}:</b> ${display_name ? `${display_name} (${vin})`: vin} 
+🚗 <b>${i18n.t('Vehicle', { lng })}:</b> ${display_name ?? vin}
 
 <i>${i18n.t('Sentry Mode activated - Check your vehicle!', { lng })}</i>
     `.trim();


### PR DESCRIPTION
# ⚙️ improve vehicle display name handling in TelegramService

- Update message formatting to use `display_name` as a fallback for `VIN`, ensuring clearer vehicle identification in alerts.
- Adjust tests to verify that the correct vehicle information is sent in messages, preventing the display of VIN when `display_name` is available.
- Enhance test coverage for alert messages in both English and French, ensuring proper localization and message structure.