### PR TITLE
Telegram bot webhook migration

### DIFF
--- a/apps/api/env.example
+++ b/apps/api/env.example
@@ -15,7 +15,9 @@ ENCRYPTION_KEY=your_encryption_key_here_min_32_chars
 
 # Telegram Bot Configuration
 TELEGRAM_BOT_TOKEN=your_telegram_bot_token_here
-TELEGRAM_BOT_USERNAME=your_bot_username_here
+TELEGRAM_WEBHOOK_BASE=https://webhook-base.url
+TELEGRAM_WEBHOOK_SECRET_PATH=your_webhook_secret_path
+TELEGRAM_WEBHOOK_SECRET_TOKEN=your_webhook_secret_token
 
 # Tesla API Configuration (Legacy - pour compatibilité)
 LETS_ENCRYPT_CERTIFICATE=your_base64_encoded_certificate_here

--- a/apps/api/src/app/telegram/telegram-webhook.controller.ts
+++ b/apps/api/src/app/telegram/telegram-webhook.controller.ts
@@ -1,0 +1,47 @@
+import {
+  Controller,
+  Post,
+  Param,
+  Req,
+  Res,
+  ForbiddenException,
+  NotFoundException,
+  Logger,
+  HttpCode,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+import { TelegramBotService } from './telegram-bot.service';
+
+@Controller('telegram')
+export class TelegramWebhookController {
+  private readonly logger = new Logger(TelegramWebhookController.name);
+
+  constructor(private readonly telegramBotService: TelegramBotService) {}
+
+  @Post('webhook/:secret')
+  @HttpCode(200)
+  async handleWebhook(
+    @Param('secret') secret: string,
+    @Req() req: Request,
+    @Res() res: Response
+  ) {
+    const expectedSecret = this.telegramBotService.getWebhookSecretPath();
+    if (secret !== expectedSecret) {
+      this.logger.warn(`Tentative webhook avec secret invalide: ${secret}`);
+      throw new NotFoundException();
+    }
+
+    const headerSecret = this.telegramBotService.getWebhookSecretToken();
+    if (headerSecret) {
+      const provided = req.headers['x-telegram-bot-api-secret-token'];
+      if (provided !== headerSecret) {
+        this.logger.warn('Tentative webhook avec secret token invalide');
+        throw new ForbiddenException();
+      }
+    }
+
+    return this.telegramBotService.handleUpdate(req, res);
+  }
+}
+
+

--- a/apps/api/src/app/telegram/telegram.module.ts
+++ b/apps/api/src/app/telegram/telegram.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { TelegramService } from './telegram.service';
 import { TelegramBotService } from './telegram-bot.service';
 import { TelegramController } from './telegram.controller';
+import { TelegramWebhookController } from './telegram-webhook.controller';
 import { TelegramConfig } from '../../entities/telegram-config.entity';
 import { User } from '../../entities/user.entity';
 import { AuthModule } from '../auth/auth.module';
@@ -16,7 +17,7 @@ import { UserModule } from '../user/user.module';
     ConsentModule,
     UserModule,
   ],
-  controllers: [TelegramController],
+  controllers: [TelegramController, TelegramWebhookController],
   providers: [TelegramService, TelegramBotService],
   exports: [TelegramService, TelegramBotService],
 })


### PR DESCRIPTION
Closes #55 

Migrate the bot to a webhook instead of polling because the polling method does not support having multiple servers running at the same time 