### PR TITLE
Add retrial mecanism for failed kafka messages and telegram bot blocked handling

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -39,11 +39,17 @@ KAFKA_CLIENT_ID=sentry-guard-api
 KAFKA_GROUP_ID=sentry-guard-consumer-group
 KAFKA_TOPIC=FleetTelemetry_V
 
-# Kafka Retry Configuration
+# Kafka Retry Configuration (for connection)
 KAFKA_MAX_RETRIES=10
 KAFKA_RETRY_DELAY=1000
 KAFKA_MAX_RETRY_DELAY=30000
 KAFKA_HEALTH_CHECK_INTERVAL=30000
+
+# Kafka Message Retry Configuration (for message processing)
+KAFKA_MESSAGE_MAX_RETRIES=3
+KAFKA_MESSAGE_RETRY_BASE_DELAY=1000
+KAFKA_MESSAGE_RETRY_MAX_DELAY=30000
+KAFKA_MESSAGE_RETRY_TIMEOUT=10000
 
 DEBUG_MESSAGES=true
 

--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -26,6 +26,7 @@ import { OciLoggingService } from '../common/services/oci-logging.service';
 import { OciLoggerService } from '../common/loggers/oci-logger.service';
 import { Vehicle } from '../entities/vehicle.entity';
 import { User } from '../entities/user.entity';
+import { RetryManager } from './messaging/kafka/retry-manager.service';
 
 @Module({
   imports: [
@@ -45,6 +46,14 @@ import { User } from '../entities/user.entity';
     AppService,
     KafkaService,
     TelemetryMessageHandlerService,
+    {
+      provide: RetryManager,
+      useFactory: () => new RetryManager(
+        parseInt(process.env.KAFKA_MESSAGE_MAX_RETRIES || '3'),
+        parseInt(process.env.KAFKA_MESSAGE_RETRY_BASE_DELAY || '1000'),
+        parseInt(process.env.KAFKA_MESSAGE_RETRY_MAX_DELAY || '30000')
+      ),
+    },
     TelemetryValidationService,
     SentryAlertHandlerService,
     {

--- a/apps/api/src/app/auth/auth.controller.spec.ts
+++ b/apps/api/src/app/auth/auth.controller.spec.ts
@@ -111,12 +111,17 @@ describe('AuthController', () => {
         email: 'test@example.com',
       };
 
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2025-06-15'));
+
       const result = await controller.getAuthStatus(mockUser);
 
       expect(result.authenticated).toBe(true);
       expect(result.expires_at).toEqual(mockUser.expires_at);
       expect(result.has_profile).toBe(true);
       expect(result.message).toBe('Valid JWT token');
+
+      jest.useRealTimers();
     });
 
     it('should return unauthenticated for a user without a token', async () => {
@@ -138,7 +143,7 @@ describe('AuthController', () => {
     it('should detect an expired token', async () => {
       const mockTokenInfo = {
         exists: true,
-        expires_at: new Date('2020-01-01'), // Past date
+        expires_at: new Date('2020-01-01'),
         created_at: new Date('2020-01-01'),
       };
 
@@ -146,13 +151,18 @@ describe('AuthController', () => {
 
       const mockUser = {
         userId: 'test-user-id',
-        jwt_expires_at: new Date('2025-01-01'), // Past date
+        jwt_expires_at: new Date('2025-01-01'),
       };
+
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2026-01-01'));
 
       const result = await controller.getAuthStatus(mockUser);
 
       expect(result.authenticated).toBe(false);
       expect(result.message).toBe('JWT token expired, please re-authenticate');
+
+      jest.useRealTimers();
     });
   });
 

--- a/apps/api/src/app/messaging/kafka/kafka.service.spec.ts
+++ b/apps/api/src/app/messaging/kafka/kafka.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { Consumer, EachBatchHandler, Batch } from 'kafkajs';
 import { KafkaService } from './kafka.service';
 import { kafkaMessageHandler, MessageHandler } from './interfaces/message-handler.interface';
+import { RetryManager } from './retry-manager.service';
 import { mock } from 'jest-mock-extended';
 
 jest.mock('kafkajs', () => ({
@@ -17,18 +18,24 @@ jest.mock('kafkajs', () => ({
 }));
 
 const mockMessageHandler = mock<MessageHandler>();
+const mockRetryManager = mock<RetryManager>();
 
 describe('The KafkaService class', () => {
   let service: KafkaService;
 
   beforeEach(async () => {
     mockMessageHandler.handleMessage.mockResolvedValue(undefined);
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         KafkaService,
         {
           provide: kafkaMessageHandler,
           useValue: mockMessageHandler,
+        },
+        {
+          provide: RetryManager,
+          useValue: mockRetryManager,
         },
       ],
     }).compile();
@@ -188,50 +195,142 @@ describe('The KafkaService class', () => {
     describe('when eachBatch is called and message processing fails', () => {
       let testBatch: Batch;
 
-      beforeEach(() => {
-        mockMessageHandler.handleMessage.mockRejectedValue(new Error('Processing failed'));
-
-        testBatch = {
-          topic: 'TeslaLogger_V',
-          partition: 0,
-          messages: [{
-            offset: '100',
-            value: Buffer.from('test message'),
-            key: null,
-            timestamp: '1234567890',
-            attributes: 0,
-            headers: {},
-          }],
-          highWatermark: '200',
-          isEmpty: jest.fn().mockReturnValue(false),
-          firstOffset: jest.fn().mockReturnValue('100'),
-          lastOffset: jest.fn().mockReturnValue('100'),
-          offsetLag: jest.fn().mockReturnValue('100'),
-          offsetLagLow: jest.fn().mockReturnValue('100'),
-        };
+      const createTestBatch = (): Batch => ({
+        topic: 'TeslaLogger_V',
+        partition: 0,
+        messages: [{
+          offset: '100',
+          value: Buffer.from('test message'),
+          key: null,
+          timestamp: '1234567890',
+          attributes: 0,
+          headers: {},
+        }],
+        highWatermark: '200',
+        isEmpty: jest.fn().mockReturnValue(false),
+        firstOffset: jest.fn().mockReturnValue('100'),
+        lastOffset: jest.fn().mockReturnValue('100'),
+        offsetLag: jest.fn().mockReturnValue('100'),
+        offsetLagLow: jest.fn().mockReturnValue('100'),
       });
 
-      it('should catch the error and not rethrow it', async () => {
+      const createEachBatchPayload = (
+        resolveOffset = jest.fn(),
+        heartbeat = jest.fn().mockResolvedValue(undefined),
+        commitOffsetsIfNecessary = jest.fn().mockResolvedValue(undefined),
+        pause = jest.fn().mockReturnValue(jest.fn())
+      ) => ({
+        batch: testBatch,
+        resolveOffset,
+        heartbeat,
+        commitOffsetsIfNecessary,
+        pause,
+        isRunning: jest.fn().mockReturnValue(true),
+        isStale: jest.fn().mockReturnValue(false),
+        uncommittedOffsets: jest.fn().mockReturnValue({}),
+      });
+
+      const verifyRetrySetup = (resolveOffset: jest.Mock, heartbeat: jest.Mock) => {
+        expect(mockRetryManager.addToRetry).toHaveBeenCalledTimes(1);
+        expect(resolveOffset).toHaveBeenCalledWith('100');
+        expect(heartbeat).toHaveBeenCalledTimes(1);
+      };
+
+      const verifyErrorConversion = (expectedMessage: string) => {
+        const addToRetryCall = mockRetryManager.addToRetry.mock.calls[0];
+        const error = addToRetryCall[1];
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toBe(expectedMessage);
+      };
+
+      beforeEach(() => {
+        mockMessageHandler.handleMessage.mockRejectedValue(new Error('Processing failed'));
+        testBatch = createTestBatch();
+      });
+
+      it('should catch the error and trigger retry mechanism', async () => {
         const resolveOffset = jest.fn();
         const heartbeat = jest.fn().mockResolvedValue(undefined);
-        const commitOffsetsIfNecessary = jest.fn().mockResolvedValue(undefined);
-        const pause = jest.fn().mockReturnValue(jest.fn());
 
-        await expect(eachBatchFunction({
-          batch: testBatch,
-          resolveOffset,
-          heartbeat,
-          commitOffsetsIfNecessary,
-          pause,
-          isRunning: jest.fn().mockReturnValue(true),
-          isStale: jest.fn().mockReturnValue(false),
-          uncommittedOffsets: jest.fn().mockReturnValue({}),
-        })).resolves.not.toThrow();
+        await expect(eachBatchFunction(createEachBatchPayload(resolveOffset, heartbeat))).resolves.not.toThrow();
 
         expect(mockMessageHandler.handleMessage).toHaveBeenCalledWith(
           testBatch.messages[0],
           expect.any(Function)
         );
+
+        expect(mockRetryManager.addToRetry).toHaveBeenCalledWith(
+          expect.any(Function),
+          expect.any(Error),
+          expect.stringContaining('kafka-TeslaLogger_V-0-100-')
+        );
+
+        const addToRetryCall = mockRetryManager.addToRetry.mock.calls[0];
+        const retryFunction = addToRetryCall[0];
+        const correlationId = addToRetryCall[2];
+
+        expect(typeof retryFunction).toBe('function');
+        expect(correlationId).toMatch(/^kafka-TeslaLogger_V-0-100-\d+$/);
+
+        verifyRetrySetup(resolveOffset, heartbeat);
+        verifyErrorConversion('Processing failed');
+      });
+
+      it('should handle string errors safely', async () => {
+        mockMessageHandler.handleMessage.mockRejectedValue('String error message');
+
+        const resolveOffset = jest.fn();
+        const heartbeat = jest.fn().mockResolvedValue(undefined);
+
+        await expect(eachBatchFunction(createEachBatchPayload(resolveOffset, heartbeat))).resolves.not.toThrow();
+
+        verifyRetrySetup(resolveOffset, heartbeat);
+        verifyErrorConversion('String error message');
+      });
+
+      it('should handle unknown object errors safely', async () => {
+        mockMessageHandler.handleMessage.mockRejectedValue({ custom: 'error', code: 500 });
+
+        const resolveOffset = jest.fn();
+        const heartbeat = jest.fn().mockResolvedValue(undefined);
+
+        await expect(eachBatchFunction(createEachBatchPayload(resolveOffset, heartbeat))).resolves.not.toThrow();
+
+        verifyRetrySetup(resolveOffset, heartbeat);
+        verifyErrorConversion('Unknown error: [object Object]');
+      });
+
+      it('should continue processing even if retry setup fails', async () => {
+        mockRetryManager.addToRetry.mockImplementation(() => {
+          throw new Error('Retry setup failed');
+        });
+
+        const resolveOffset = jest.fn();
+        const heartbeat = jest.fn().mockResolvedValue(undefined);
+
+        await expect(eachBatchFunction(createEachBatchPayload(resolveOffset, heartbeat))).resolves.not.toThrow();
+
+        verifyRetrySetup(resolveOffset, heartbeat);
+      });
+
+      it('should continue processing even if resolveOffset fails', async () => {
+        const resolveOffset = jest.fn().mockImplementation(() => {
+          throw new Error('Offset commit failed');
+        });
+        const heartbeat = jest.fn().mockResolvedValue(undefined);
+
+        await expect(eachBatchFunction(createEachBatchPayload(resolveOffset, heartbeat))).resolves.not.toThrow();
+
+        verifyRetrySetup(resolveOffset, heartbeat);
+      });
+
+      it('should continue processing even if heartbeat fails', async () => {
+        const resolveOffset = jest.fn();
+        const heartbeat = jest.fn().mockRejectedValue(new Error('Heartbeat failed'));
+
+        await expect(eachBatchFunction(createEachBatchPayload(resolveOffset, heartbeat))).resolves.not.toThrow();
+
+        verifyRetrySetup(resolveOffset, heartbeat);
       });
     });
   });

--- a/apps/api/src/app/messaging/kafka/retry-manager.service.spec.ts
+++ b/apps/api/src/app/messaging/kafka/retry-manager.service.spec.ts
@@ -1,0 +1,168 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RetryManager } from './retry-manager.service';
+
+describe('The RetryManager class', () => {
+  let service: RetryManager;
+  let mockExecute: jest.MockedFunction<() => Promise<void>>;
+  let maxRetries: number;
+  let baseDelay: number;
+  let maxDelay: number;
+  
+  beforeEach(async () => {
+    maxRetries = 3;
+    baseDelay = 1000;
+    maxDelay = 30000;
+    mockExecute = jest.fn();
+    
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        {
+          provide: RetryManager,
+          useFactory: () => new RetryManager(maxRetries, baseDelay, maxDelay),
+        },
+      ],
+    }).compile();
+    
+    service = module.get(RetryManager);
+    
+    jest.useFakeTimers();
+  });
+  
+  afterEach(() => {
+    jest.useRealTimers();
+    service.stop();
+    mockExecute.mockReset();
+  });
+  
+  describe('The addToRetry() method', () => {
+    describe('When adding first attempt', () => {
+      it('should execute operation immediately', () => {
+        mockExecute.mockResolvedValue(undefined);
+        
+        service.addToRetry(mockExecute, new Error('Test error'), 'test-1', 1);
+        
+        expect(mockExecute).toHaveBeenCalledTimes(1);
+      });
+      
+      it('should schedule retry when operation fails', async () => {
+        let callCount = 0;
+        mockExecute.mockImplementation(async () => {
+          callCount++;
+          if (callCount === 1) {
+            throw new Error('First failure');
+          }
+          return undefined;
+        });
+        
+        service.addToRetry(mockExecute, new Error('Test error'), 'test-retry', 1);
+        
+        expect(mockExecute).toHaveBeenCalledTimes(1);
+        
+        await jest.advanceTimersByTimeAsync(2000);
+
+        expect(mockExecute).toHaveBeenCalledTimes(2);
+      });
+    });
+    
+    describe('When adding retry attempts', () => {
+      it('should schedule retry with exponential backoff', async () => {
+        mockExecute.mockResolvedValue(undefined);
+        
+        service.addToRetry(mockExecute, new Error('Test error'), 'test-1', 2);
+        service.addToRetry(mockExecute, new Error('Test error'), 'test-2', 2);
+        
+        await jest.advanceTimersByTimeAsync(2000);
+        
+        expect(mockExecute).toHaveBeenCalledTimes(2);
+      });
+    });
+    
+    describe('When operation fails and retries are scheduled', () => {
+      it('should retry failed operation with increasing delays', async () => {
+        mockExecute.mockImplementation(async () => {
+          throw new Error('Always fails');
+        });
+
+        service.addToRetry(mockExecute, new Error('Initial error'), 'test-retry', 1);
+
+        expect(mockExecute).toHaveBeenCalledTimes(1);
+
+        await jest.advanceTimersByTimeAsync(6000);
+        expect(mockExecute).toHaveBeenCalledTimes(3);
+      });
+      
+      it('should eventually succeed after retries', async () => {
+        let callCount = 0;
+        mockExecute.mockImplementation(async () => {
+          callCount++;
+          if (callCount <= 2) throw new Error(`Failure ${callCount}`);
+          return undefined;
+        });
+
+        service.addToRetry(mockExecute, new Error('Initial error'), 'test-success', 1);
+
+        expect(mockExecute).toHaveBeenCalledTimes(1);
+
+        await jest.advanceTimersByTimeAsync(6000);
+        expect(mockExecute).toHaveBeenCalledTimes(3);
+      });
+    });
+    
+    describe('When max attempts reached', () => {
+      it('should not execute operation and not schedule retry', async () => {
+        service.addToRetry(mockExecute, new Error('Test error'), 'test-1', 4);
+        
+        await jest.advanceTimersByTimeAsync(10000);
+        
+        expect(mockExecute).toHaveBeenCalledTimes(0);
+      });
+      
+      it('should stop retrying after max attempts even with failures', async () => {
+        mockExecute.mockImplementation(async () => {
+          throw new Error('Always fails');
+        });
+        
+        service.addToRetry(mockExecute, new Error('Initial error'), 'test-max-fail', 1);
+        
+        expect(mockExecute).toHaveBeenCalledTimes(1);
+        
+        await jest.advanceTimersByTimeAsync(6000);
+        expect(mockExecute).toHaveBeenCalledTimes(3);
+        
+        await jest.advanceTimersByTimeAsync(4000);
+        expect(mockExecute).toHaveBeenCalledTimes(3);
+      });
+    });
+  });
+  
+  
+  describe('The clearPendingRetries() method', () => {
+    it('should clear all pending retries', async () => {
+      mockExecute.mockResolvedValue(undefined);
+      
+      service.addToRetry(mockExecute, new Error('Test'), 'test-1', 2);
+      service.addToRetry(mockExecute, new Error('Test'), 'test-2', 2);
+      
+      service.stop();
+      
+      await jest.advanceTimersByTimeAsync(1000);
+      
+      expect(mockExecute).toHaveBeenCalledTimes(0);
+    });
+  });
+  
+  describe('The stop() method', () => {
+    it('should clear all pending retries', async () => {
+      mockExecute.mockResolvedValue(undefined);
+      
+      service.addToRetry(mockExecute, new Error('Test'), 'test-1', 2);
+      
+      service.stop();
+      
+      await jest.advanceTimersByTimeAsync(1000);
+      
+      expect(mockExecute).toHaveBeenCalledTimes(0);
+    });
+  });
+  
+});

--- a/apps/api/src/app/messaging/kafka/retry-manager.service.ts
+++ b/apps/api/src/app/messaging/kafka/retry-manager.service.ts
@@ -1,0 +1,93 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+@Injectable()
+export class RetryManager {
+  private readonly logger = new Logger(RetryManager.name);
+  private readonly backoffBase = 2;
+  private pendingRetries = new Map<string, NodeJS.Timeout>();
+
+  constructor(
+    private readonly maxRetries: number,
+    private readonly baseDelay: number,
+    private readonly maxDelay: number,
+  ) {}
+
+  addToRetry(
+    execute: () => Promise<void>,
+    error: Error,
+    correlationId: string,
+    attemptCount = 1
+  ): void {
+    if (attemptCount > this.maxRetries) {
+      this.logger.error(
+        `[RETRY_FAILED][${correlationId}] Operation failed permanently after ${attemptCount} attempts:`,
+        error.message
+      );
+      return;
+    }
+
+    if (attemptCount === 1) {
+      this.executeRetry(execute, correlationId, attemptCount);
+    } else {
+      const delay = this.calculateDelay(attemptCount);
+
+      this.logger.warn(
+        `[RETRY_SCHEDULED][${correlationId}] Operation scheduled for retry ${attemptCount}/${this.maxRetries} in ${delay}ms`
+      );
+
+      const timeoutId = setTimeout(() => {
+        this.pendingRetries.delete(correlationId);
+        this.executeRetry(execute, correlationId, attemptCount);
+      }, delay);
+
+      this.pendingRetries.set(correlationId, timeoutId);
+    }
+  }
+
+  stop(): void {
+    this.clearPendingRetries();
+  }
+
+  private clearPendingRetries(): void {
+    for (const timeoutId of this.pendingRetries.values()) {
+      clearTimeout(timeoutId);
+    }
+    this.pendingRetries.clear();
+    this.logger.log('Pending retries cleared');
+  }
+
+  private async executeRetry(
+    execute: () => Promise<void>,
+    correlationId: string,
+    attemptCount: number
+  ): Promise<void> {
+    try {
+      this.logger.log(
+        `[RETRY_ATTEMPT][${correlationId}] Retrying operation (attempt ${attemptCount}/${this.maxRetries})`
+      );
+
+      await execute();
+
+      this.logger.log(
+        `[RETRY_SUCCESS][${correlationId}] Operation succeeded on retry ${attemptCount}`
+      );
+
+    } catch (error) {
+      this.logger.error(
+        `[RETRY_FAILED][${correlationId}] Operation failed on attempt ${attemptCount}:`,
+        error instanceof Error ? error.message : String(error)
+      );
+
+      this.addToRetry(execute, error as Error, correlationId, attemptCount + 1);
+    }
+  }
+
+  private calculateDelay(attemptCount: number): number {
+    const backoffMultiplier = Math.pow(this.backoffBase, attemptCount - 1);
+
+    return Math.min(
+      this.baseDelay * backoffMultiplier,
+      this.maxDelay
+    );
+  }
+}

--- a/apps/api/src/app/telegram/handlers/telegram-failure-handler.service.spec.ts
+++ b/apps/api/src/app/telegram/handlers/telegram-failure-handler.service.spec.ts
@@ -1,0 +1,102 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { mock, MockProxy } from 'jest-mock-extended';
+import { TelegramFailureHandlerService } from './telegram-failure-handler.service';
+import { TelegramConfigService } from '../telegram-config.service';
+
+describe('The TelegramFailureHandlerService class', () => {
+  let service: TelegramFailureHandlerService;
+  let mockTelegramConfigService: MockProxy<TelegramConfigService>;
+
+  beforeEach(async () => {
+    mockTelegramConfigService = mock<TelegramConfigService>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TelegramFailureHandlerService,
+        {
+          provide: TelegramConfigService,
+          useValue: mockTelegramConfigService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<TelegramFailureHandlerService>(TelegramFailureHandlerService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('The canHandle() method', () => {
+    describe('When error message contains "bot was blocked by the user"', () => {
+      it('should return true', () => {
+        const error = new Error('bot was blocked by the user');
+        expect(service.canHandle(error)).toBe(true);
+      });
+    });
+
+    describe('When error message contains "forbidden: bot was blocked"', () => {
+      it('should return true', () => {
+        const error = new Error('forbidden: bot was blocked');
+        expect(service.canHandle(error)).toBe(true);
+      });
+    });
+
+    describe('When error message contains "chat not found"', () => {
+      it('should return true', () => {
+        const error = new Error('chat not found');
+        expect(service.canHandle(error)).toBe(true);
+      });
+    });
+
+    describe('When error message uses mixed case', () => {
+      it('should return true', () => {
+        const error = new Error('Bot Was Blocked By The User');
+        expect(service.canHandle(error)).toBe(true);
+      });
+    });
+
+    describe('When error message is not related to bot blocking', () => {
+      it('should return false', () => {
+        const error = new Error('network timeout');
+        expect(service.canHandle(error)).toBe(false);
+      });
+    });
+
+    describe('When error message is empty', () => {
+      it('should return false', () => {
+        const error = new Error('');
+        expect(service.canHandle(error)).toBe(false);
+      });
+    });
+  });
+
+  describe('The handleFailure() method', () => {
+    const userId = 'user123';
+
+    describe('When removeTelegramConfig succeeds', () => {
+      it('should remove Telegram configuration', async () => {
+        mockTelegramConfigService.removeTelegramConfig.mockResolvedValue(undefined);
+
+        const error = new Error('bot was blocked by the user');
+        await expect(service.handleFailure(error, userId)).resolves.not.toThrow();
+
+        expect(mockTelegramConfigService.removeTelegramConfig).toHaveBeenCalledWith(userId);
+        expect(mockTelegramConfigService.removeTelegramConfig).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('When removeTelegramConfig fails', () => {
+      it('should throw the removal error', async () => {
+        const removalError = new Error('Database connection failed');
+        mockTelegramConfigService.removeTelegramConfig.mockRejectedValue(removalError);
+
+        const error = new Error('bot was blocked by the user');
+        await expect(service.handleFailure(error, userId)).rejects.toThrow(removalError);
+
+        expect(mockTelegramConfigService.removeTelegramConfig).toHaveBeenCalledWith(userId);
+        expect(mockTelegramConfigService.removeTelegramConfig).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/apps/api/src/app/telegram/handlers/telegram-failure-handler.service.ts
+++ b/apps/api/src/app/telegram/handlers/telegram-failure-handler.service.ts
@@ -1,0 +1,31 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ITelegramFailureHandler } from '../interfaces/telegram-failure-handler.interface';
+import { TelegramConfigService } from '../telegram-config.service';
+
+@Injectable()
+export class TelegramFailureHandlerService implements ITelegramFailureHandler {
+  private readonly logger = new Logger(TelegramFailureHandlerService.name);
+
+  constructor(
+    private readonly telegramConfigService: TelegramConfigService,
+  ) {}
+
+  canHandle(error: Error): boolean {
+    const errorMessage = error.message.toLowerCase();
+    return errorMessage.includes('bot was blocked by the user') ||
+           errorMessage.includes('forbidden: bot was blocked') ||
+           errorMessage.includes('chat not found');
+  }
+
+  async handleFailure(error: Error, userId: string): Promise<void> {
+    this.logger.warn(`[TELEGRAM_BLOCKED] Bot blocked for user ${userId}, removing Telegram configuration`);
+
+    try {
+      await this.telegramConfigService.removeTelegramConfig(userId);
+      this.logger.log(`[TELEGRAM_BLOCKED] Successfully removed Telegram configuration for user: ${userId}`);
+    } catch (removalError) {
+      this.logger.error(`[TELEGRAM_CONFIG_ERROR] Failed to remove Telegram configuration for user ${userId}:`, removalError);
+      throw removalError;
+    }
+  }
+}

--- a/apps/api/src/app/telegram/interfaces/telegram-failure-handler.interface.ts
+++ b/apps/api/src/app/telegram/interfaces/telegram-failure-handler.interface.ts
@@ -1,0 +1,6 @@
+export const telegramFailureHandler = Symbol('TelegramFailureHandler');
+
+export interface ITelegramFailureHandler {
+  canHandle(error: Error): boolean;
+  handleFailure(error: Error, userId: string): Promise<void>;
+}

--- a/apps/api/src/app/telegram/telegram-config.service.test.ts
+++ b/apps/api/src/app/telegram/telegram-config.service.test.ts
@@ -1,0 +1,73 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { mock, MockProxy } from 'jest-mock-extended';
+import { Repository } from 'typeorm';
+import { TelegramConfig } from '../../entities/telegram-config.entity';
+import { TelegramConfigService } from './telegram-config.service';
+
+describe('The TelegramConfigService class', () => {
+  let service: TelegramConfigService;
+  let mockRepository: MockProxy<Repository<TelegramConfig>>;
+
+  beforeEach(async () => {
+    mockRepository = mock<Repository<TelegramConfig>>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TelegramConfigService,
+        {
+          provide: getRepositoryToken(TelegramConfig),
+          useValue: mockRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<TelegramConfigService>(TelegramConfigService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('The removeTelegramConfig() method', () => {
+    describe('When configuration is successfully removed', () => {
+      it('should delete the config and log success', async () => {
+        const userId = 'user-123';
+
+        mockRepository.delete.mockResolvedValue({ affected: 1, raw: {} });
+
+        await expect(service.removeTelegramConfig(userId)).resolves.not.toThrow();
+
+        expect(mockRepository.delete).toHaveBeenCalledWith({ userId });
+        expect(mockRepository.delete).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('When no configuration is found', () => {
+      it('should attempt deletion and log warning', async () => {
+        const userId = 'user-456';
+
+        mockRepository.delete.mockResolvedValue({ affected: 0, raw: {} });
+
+        await expect(service.removeTelegramConfig(userId)).resolves.not.toThrow();
+
+        expect(mockRepository.delete).toHaveBeenCalledWith({ userId });
+        expect(mockRepository.delete).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('When database operation fails', () => {
+      it('should throw the error', async () => {
+        const userId = 'user-789';
+        const testError = new Error('Database connection failed');
+
+        mockRepository.delete.mockRejectedValue(testError);
+
+        await expect(service.removeTelegramConfig(userId)).rejects.toThrow(testError);
+
+        expect(mockRepository.delete).toHaveBeenCalledWith({ userId });
+        expect(mockRepository.delete).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/apps/api/src/app/telegram/telegram-config.service.ts
+++ b/apps/api/src/app/telegram/telegram-config.service.ts
@@ -1,0 +1,29 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { TelegramConfig } from '../../entities/telegram-config.entity';
+
+@Injectable()
+export class TelegramConfigService {
+  private readonly logger = new Logger(TelegramConfigService.name);
+
+  constructor(
+    @InjectRepository(TelegramConfig)
+    private readonly telegramConfigRepository: Repository<TelegramConfig>,
+  ) {}
+
+  async removeTelegramConfig(userId: string): Promise<void> {
+    try {
+      const result = await this.telegramConfigRepository.delete({ userId });
+
+      if (result.affected && result.affected > 0) {
+        this.logger.log(`[TELEGRAM_CONFIG_REMOVED] Successfully removed Telegram configuration for user: ${userId}`);
+      } else {
+        this.logger.warn(`[TELEGRAM_CONFIG_NOT_FOUND] No Telegram configuration found for user: ${userId}`);
+      }
+    } catch (error) {
+      this.logger.error(`[TELEGRAM_CONFIG_ERROR] Failed to remove Telegram configuration for user ${userId}:`, error);
+      throw error;
+    }
+  }
+}

--- a/apps/api/src/app/telegram/telegram.module.ts
+++ b/apps/api/src/app/telegram/telegram.module.ts
@@ -5,6 +5,9 @@ import { TelegramBotService } from './telegram-bot.service';
 import { TelegramController } from './telegram.controller';
 import { TelegramWebhookController } from './telegram-webhook.controller';
 import { TelegramKeyboardBuilderService } from './telegram-keyboard-builder.service';
+import { TelegramConfigService } from './telegram-config.service';
+import { TelegramFailureHandlerService } from './handlers/telegram-failure-handler.service';
+import { telegramFailureHandler } from './interfaces/telegram-failure-handler.interface';
 import { TelegramConfig } from '../../entities/telegram-config.entity';
 import { User } from '../../entities/user.entity';
 import { AuthModule } from '../auth/auth.module';
@@ -19,7 +22,17 @@ import { UserModule } from '../user/user.module';
     UserModule,
   ],
   controllers: [TelegramController, TelegramWebhookController],
-  providers: [TelegramService, TelegramBotService, TelegramKeyboardBuilderService],
-  exports: [TelegramService, TelegramBotService, TelegramKeyboardBuilderService],
+  providers: [
+    TelegramService,
+    TelegramBotService,
+    TelegramKeyboardBuilderService,
+    TelegramConfigService,
+    TelegramFailureHandlerService,
+    {
+      provide: telegramFailureHandler,
+      useClass: TelegramFailureHandlerService,
+    },
+  ],
+  exports: [TelegramService, TelegramBotService, TelegramKeyboardBuilderService, TelegramConfigService],
 })
 export class TelegramModule {}


### PR DESCRIPTION
Closes #74
Closes #75 

- Implement a retry mechanism for handling failed Kafka messages asynchronously.
- Remove the Telegram configuration of users who blocked our bot to prevent sending messages when we are not authorized. 