### PR TITLE
refactor: convert public pages to Server Components with SSR i18n

### DIFF
--- a/apps/webapp/src/app/faq/page.tsx
+++ b/apps/webapp/src/app/faq/page.tsx
@@ -1,22 +1,73 @@
-'use client';
+import type { Metadata } from 'next';
+import {
+  getLocale,
+  getTranslation,
+  renderRichTranslation,
+  stripRichTextTags,
+} from '../../lib/server-i18n';
+import { faqCategories } from '../../lib/faq-data';
+import PublicLayout from '../../components/PublicLayout';
+import { ContactSection } from '../../components/faq/ContactSection';
 
-import { useTranslation } from 'react-i18next';
-import Layout from '../../components/Layout';
-import FAQContent from '../../components/faq/FAQContent';
+export const metadata: Metadata = {
+  title: 'FAQ - SentryGuard',
+  description:
+    'Frequently asked questions about SentryGuard. Learn how to protect your Tesla with real-time Sentry Mode monitoring and Telegram alerts.',
+  keywords: [
+    'SentryGuard FAQ',
+    'Tesla Sentry Mode',
+    'Tesla Security',
+    'Telegram Alerts',
+    'Tesla Monitoring Help',
+  ],
+  openGraph: {
+    title: 'FAQ - SentryGuard',
+    description:
+      'Frequently asked questions about SentryGuard Tesla monitoring.',
+    type: 'website',
+  },
+};
 
-export default function FAQPage() {
-  const { t } = useTranslation('common');
+function generateFaqJsonLd(t: (key: string) => string) {
+  const questions = faqCategories.flatMap((category) =>
+    category.items.map((item) => ({
+      '@type': 'Question',
+      name: t(item.questionKey),
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: stripRichTextTags(t(item.answerKey)),
+      },
+    }))
+  );
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: questions,
+  };
+}
+
+export default async function FAQPage() {
+  const locale = await getLocale();
+  const t = getTranslation(locale);
+  const jsonLd = generateFaqJsonLd(t);
 
   return (
-    <Layout
+    <PublicLayout
+      locale={locale}
       navigationItems={[
         {
           label: '← Back to home',
           href: '/',
-          primary: false
-        }
+          primary: false,
+        },
       ]}
     >
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+
       <div className="container mx-auto px-6 py-16">
         <div className="max-w-4xl mx-auto">
           <div className="text-center mb-16">
@@ -28,9 +79,61 @@ export default function FAQPage() {
             </p>
           </div>
 
-          <FAQContent />
+          <div className="space-y-6">
+            {faqCategories.map((category, categoryIndex) => (
+              <div
+                key={categoryIndex}
+                className="rounded-2xl shadow-sm border overflow-hidden bg-white border-gray-200"
+              >
+                <div className="px-6 py-4 border-b border-gray-200">
+                  <h3 className="text-xl font-semibold text-gray-900">
+                    {t(category.titleKey)}
+                  </h3>
+                </div>
+                <div className="divide-y divide-gray-200">
+                  {category.items.map((item, itemIndex) => (
+                    <details
+                      key={itemIndex}
+                      className="group transition-all duration-200 hover:bg-gray-50"
+                    >
+                      <summary className="w-full px-6 py-5 text-left flex items-start justify-between gap-4 cursor-pointer list-none [&::-webkit-details-marker]:hidden">
+                        <span className="text-base font-medium flex-1 text-left text-gray-900">
+                          {t(item.questionKey)}
+                        </span>
+                        <svg
+                          className="w-5 h-5 flex-shrink-0 transition-all duration-300 mt-0.5 text-gray-400 group-open:rotate-180 group-open:text-red-600"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M19 9l-7 7-7-7"
+                          />
+                        </svg>
+                      </summary>
+                      <div className="px-6 pb-5 pt-0">
+                        <p className="leading-relaxed text-sm text-gray-600">
+                          {item.answerLinks
+                            ? renderRichTranslation(
+                                t(item.answerKey),
+                                item.answerLinks
+                              )
+                            : t(item.answerKey)}
+                        </p>
+                      </div>
+                    </details>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <ContactSection />
         </div>
       </div>
-    </Layout>
+    </PublicLayout>
   );
 }

--- a/apps/webapp/src/app/layout.tsx
+++ b/apps/webapp/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { Provider as RollbarProvider } from '@rollbar/react';
 import I18nProvider from '../components/I18nProvider';
 import BuyMeACoffeeWidget from '../components/BuyMeACoffeeWidget';
 import { clientConfig } from '@/logger/rollbar.config';
+import { getLocale } from '../lib/server-i18n';
 
 export const metadata: Metadata = {
   title: 'SentryGuard - Protect Your Tesla',
@@ -26,35 +27,25 @@ export const metadata: Metadata = {
     type: 'website',
   },
   other: {
-    google: 'notranslate'
-  }
+    google: 'notranslate',
+  },
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const locale = await getLocale();
+
   return (
     <RollbarProvider config={clientConfig}>
-      <html lang="en" suppressHydrationWarning translate="no">
-        <head>
-          <script
-            src="https://cdnjs.buymeacoffee.com/1.0.0/widget.prod.min.js"
-            data-name="BMC-Widget"
-            data-cfasync="false"
-            data-id="sentryguardorg"
-            data-description="Support me on Buy me a coffee!"
-            data-message="SentryGuard depends on donations to operate. Your support keeps us running! ☕"
-            data-color="#b91c1c"
-            data-position="Right"
-            data-x_margin="18"
-            data-y_margin="18"
-          />
-          <Script
-            id="crisp-widget"
-            strategy="beforeInteractive"
-          >
+      <html lang={locale} translate="no">
+        <head />
+        <body suppressHydrationWarning>
+          <I18nProvider initialLocale={locale}>{children}</I18nProvider>
+          <BuyMeACoffeeWidget />
+          <Script id="crisp-widget" strategy="afterInteractive">
             {`
               window.$crisp = [];
               window.CRISP_WEBSITE_ID = "04ce8de3-dcd5-454b-bd56-66643019ccc0";
@@ -67,10 +58,6 @@ export default function RootLayout({
               })();
             `}
           </Script>
-        </head>
-        <body>
-          <I18nProvider>{children}</I18nProvider>
-          <BuyMeACoffeeWidget />
         </body>
       </html>
     </RollbarProvider>

--- a/apps/webapp/src/app/page.tsx
+++ b/apps/webapp/src/app/page.tsx
@@ -1,73 +1,75 @@
-'use client';
-
-import { Suspense, useEffect } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { useTranslation } from 'react-i18next';
-import { useAuth } from '../lib/useAuth';
+import type { Metadata } from 'next';
+import { getLocale, getTranslation } from '../lib/server-i18n';
+import PublicLayout from '../components/PublicLayout';
+import AuthRedirect from '../components/AuthRedirect';
 import TeslaLoginButton from '../components/TeslaLoginButton';
-import Layout from '../components/Layout';
 
-function ExpiredBanner() {
-  const { t } = useTranslation('common');
-  const searchParams = useSearchParams();
-  const expired = searchParams.get('expired');
+export const metadata: Metadata = {
+  title: 'SentryGuard - Protect Your Tesla',
+  description:
+    "Real-time monitoring and instant Telegram alerts for your Tesla vehicle's Sentry Mode. Battery-efficient, secure, and open-source.",
+  keywords: [
+    'Tesla',
+    'Sentry Mode',
+    'Security',
+    'Vehicle Monitoring',
+    'Telegram Alerts',
+    'Tesla Protection',
+    'Tesla Sentry Mode Alerts',
+  ],
+  openGraph: {
+    title: 'SentryGuard - Protect Your Tesla',
+    description:
+      "Real-time monitoring and instant Telegram alerts for your Tesla vehicle's Sentry Mode.",
+    type: 'website',
+  },
+};
 
-  if (!expired) return null;
-
-  return (
-    <div className="max-w-4xl mx-auto mb-6 bg-blue-50 border-l-4 border-blue-400 p-4 rounded">
-      <p className="text-blue-800 font-medium">
-        {t('Your session has expired. Please log in again.')}
-      </p>
-    </div>
-  );
-}
-
-export default function HomePage() {
-  const { t } = useTranslation('common');
-  const { isAuthenticated, isLoading } = useAuth();
-  const router = useRouter();
-
-  useEffect(() => {
-    if (!isLoading && isAuthenticated) {
-      router.push('/dashboard');
-    }
-  }, [isLoading, isAuthenticated, router]);
-
-  if (isLoading) {
-    return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="text-center">
-          <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-red-600"></div>
-          <p className="mt-4 text-gray-600">{t('Loading...')}</p>
-        </div>
-      </div>
-    );
-  }
-
-  if (isAuthenticated) {
-    return null;
-  }
+export default async function HomePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ expired?: string }>;
+}) {
+  const [locale, params] = await Promise.all([getLocale(), searchParams]);
+  const t = getTranslation(locale);
+  const isExpired = params.expired === 'true';
 
   return (
-    <Layout
+    <PublicLayout
+      locale={locale}
       navigationItems={[
         {
           label: 'FAQ',
           href: '/faq',
           icon: (
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
             </svg>
           ),
-          primary: true
-        }
+          primary: true,
+        },
       ]}
     >
+      <AuthRedirect />
+
       <div className="container mx-auto px-6 py-20">
-        <Suspense fallback={null}>
-          <ExpiredBanner />
-        </Suspense>
+        {isExpired ? (
+          <div className="max-w-4xl mx-auto mb-6 bg-blue-50 border-l-4 border-blue-400 p-4 rounded">
+            <p className="text-blue-800 font-medium">
+              {t('Your session has expired. Please log in again.')}
+            </p>
+          </div>
+        ) : null}
 
         <div className="max-w-4xl mx-auto text-center">
           <h2 className="text-5xl md:text-6xl font-bold mb-6 bg-gradient-to-r from-red-500 via-red-600 to-red-700 text-transparent bg-clip-text p-1">
@@ -80,7 +82,7 @@ export default function HomePage() {
           </p>
           <p className="text-lg text-gray-600 mb-12 max-w-2xl mx-auto">
             {t(
-              "Telemetry monitors Sentry Mode and sends alerts without draining battery"
+              'Telemetry monitors Sentry Mode and sends alerts without draining battery'
             )}
           </p>
 
@@ -92,7 +94,6 @@ export default function HomePage() {
         </div>
       </div>
 
-      {/* Features Grid */}
       <div className="container mx-auto px-6 py-12">
         <div className="grid md:grid-cols-3 gap-8 max-w-5xl mx-auto">
           <div className="bg-white rounded-xl p-6 border border-gray-300 hover:border-red-600 transition-colors duration-300">
@@ -111,7 +112,9 @@ export default function HomePage() {
                 />
               </svg>
             </div>
-            <h3 className="text-xl font-semibold mb-2">{t('Instant Alerts')}</h3>
+            <h3 className="text-xl font-semibold mb-2">
+              {t('Instant Alerts')}
+            </h3>
             <p className="text-gray-600">
               {t(
                 "Receive real-time Telegram notifications when your vehicle's Sentry Mode is triggered."
@@ -173,7 +176,6 @@ export default function HomePage() {
         </div>
       </div>
 
-      {/* Funding Section */}
       <div className="container mx-auto px-6 py-12">
         <div className="max-w-3xl mx-auto text-center">
           <h3 className="text-2xl font-semibold mb-4 text-gray-600">
@@ -191,6 +193,6 @@ export default function HomePage() {
           </p>
         </div>
       </div>
-    </Layout>
+    </PublicLayout>
   );
 }

--- a/apps/webapp/src/components/AuthRedirect.tsx
+++ b/apps/webapp/src/components/AuthRedirect.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '../lib/useAuth';
+
+export default function AuthRedirect() {
+  const { isAuthenticated, isLoading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isLoading && isAuthenticated) {
+      router.push('/dashboard');
+    }
+  }, [isLoading, isAuthenticated, router]);
+
+  if (!isLoading && !isAuthenticated) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 bg-gray-50 flex items-center justify-center">
+      <div className="text-center">
+        <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-red-600" />
+      </div>
+    </div>
+  );
+}

--- a/apps/webapp/src/components/BuyMeACoffeeWidget.tsx
+++ b/apps/webapp/src/components/BuyMeACoffeeWidget.tsx
@@ -4,23 +4,40 @@ import { useEffect } from 'react';
 
 export default function BuyMeACoffeeWidget() {
   useEffect(() => {
-    // Wait for BMC script to load, then trigger DOMContentLoaded
-    const checkAndInit = setInterval(() => {
-      if ((window as any).bmcWidget) {
-        clearInterval(checkAndInit);
-        const event = new Event('DOMContentLoaded', {
-          bubbles: true,
-          cancelable: true,
-        });
-        window.dispatchEvent(event);
-      }
-    }, 100);
+    const script = document.createElement('script');
+    script.src = 'https://cdnjs.buymeacoffee.com/1.0.0/widget.prod.min.js';
+    script.setAttribute('data-name', 'BMC-Widget');
+    script.setAttribute('data-cfasync', 'false');
+    script.setAttribute('data-id', 'sentryguardorg');
+    script.setAttribute('data-description', 'Support me on Buy me a coffee!');
+    script.setAttribute(
+      'data-message',
+      'SentryGuard depends on donations to operate. Your support keeps us running!'
+    );
+    script.setAttribute('data-color', '#b91c1c');
+    script.setAttribute('data-position', 'Right');
+    script.setAttribute('data-x_margin', '18');
+    script.setAttribute('data-y_margin', '18');
+    script.async = true;
+
+    script.onload = () => {
+      const event = new Event('DOMContentLoaded', {
+        bubbles: true,
+        cancelable: true,
+      });
+      window.dispatchEvent(event);
+    };
+
+    document.body.appendChild(script);
 
     return () => {
-      clearInterval(checkAndInit);
+      if (script.parentNode) {
+        script.parentNode.removeChild(script);
+      }
+      const bmcButton = document.getElementById('bmc-wbtn');
+      if (bmcButton) bmcButton.remove();
     };
   }, []);
 
   return null;
 }
-

--- a/apps/webapp/src/components/I18nProvider.tsx
+++ b/apps/webapp/src/components/I18nProvider.tsx
@@ -2,7 +2,7 @@
 
 import { createInstance, Resource, i18n as I18n } from 'i18next';
 import { I18nextProvider, initReactI18next } from 'react-i18next';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { getUserLanguage, hasToken } from '../lib/api';
 
 const resources: Resource = {
@@ -14,72 +14,61 @@ const resources: Resource = {
   },
 };
 
-export const i18n: I18n = createInstance({
+export const i18n: I18n = createInstance();
+i18n.use(initReactI18next).init({
   lng: 'en',
   fallbackLng: 'en',
   defaultNS: 'common',
   resources,
   initImmediate: false,
+  react: {
+    useSuspense: false,
+  },
 });
+
+function setLocaleCookie(lang: string) {
+  document.cookie = `locale=${lang};path=/;max-age=${365 * 24 * 60 * 60};SameSite=Lax`;
+}
 
 interface I18nProviderProps {
   children: React.ReactNode;
+  initialLocale?: string;
 }
 
-export default function I18nProvider({ children }: I18nProviderProps) {
-  const [isLoaded, setIsLoaded] = useState(false);
+export default function I18nProvider({
+  children,
+  initialLocale = 'en',
+}: I18nProviderProps) {
+  const lastSyncedLocale = useRef<string | null>(null);
 
-  useEffect(() => {
-    const initializeI18n = async () => {
-      if (!i18n.isInitialized) {
-        await i18n
-          .use(initReactI18next)
-          .init({
-            lng: 'en',
-            fallbackLng: 'en',
-            defaultNS: 'common',
-            resources,
-            initImmediate: false,
-            react: {
-              useSuspense: false,
-            },
-          });
-      }
-
-      let languageToUse = 'en';
-
-      if (hasToken()) {
-        try {
-          const response = await getUserLanguage();
-          languageToUse = response.language;
-        } catch {
-          const browserLang = navigator.language.split('-')[0];
-          languageToUse = browserLang === 'fr' ? 'fr' : 'en';
-        }
-      } else {
-        const browserLang = navigator.language.split('-')[0];
-        languageToUse = browserLang === 'fr' ? 'fr' : 'en';
-      }
-
-      await i18n.changeLanguage(languageToUse);
-      document.documentElement.lang = languageToUse;
-      setIsLoaded(true);
-    };
-
-    initializeI18n();
-  }, []);
-
-  if (!isLoaded) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-tesla-600"></div>
-      </div>
-    );
+  if (lastSyncedLocale.current !== initialLocale) {
+    if (i18n.language !== initialLocale) {
+      i18n.changeLanguage(initialLocale);
+    }
+    lastSyncedLocale.current = initialLocale;
   }
 
-  return (
-    <I18nextProvider i18n={i18n}>
-      {children}
-    </I18nextProvider>
-  );
+  useEffect(() => {
+    const syncAuthenticatedLanguage = async () => {
+      if (!hasToken()) {
+        return;
+      }
+
+      try {
+        const response = await getUserLanguage();
+
+        if (response.language !== i18n.language) {
+          await i18n.changeLanguage(response.language);
+          document.documentElement.lang = response.language;
+          setLocaleCookie(response.language);
+        }
+      } catch {
+        // Keep current language from server detection
+      }
+    };
+
+    syncAuthenticatedLanguage();
+  }, [initialLocale]);
+
+  return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
 }

--- a/apps/webapp/src/components/LanguageSwitcher.tsx
+++ b/apps/webapp/src/components/LanguageSwitcher.tsx
@@ -1,11 +1,17 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import { i18n } from './I18nProvider';
 import { updateUserLanguage, hasToken } from '../lib/api';
 
+function setLocaleCookie(lang: string) {
+  document.cookie = `locale=${lang};path=/;max-age=${365 * 24 * 60 * 60};SameSite=Lax`;
+}
+
 export default function LanguageSwitcher() {
-  const [currentLang, setCurrentLang] = useState('en');
+  const [currentLang, setCurrentLang] = useState(i18n.language || 'en');
+  const router = useRouter();
 
   useEffect(() => {
     setCurrentLang(i18n.language);
@@ -21,7 +27,10 @@ export default function LanguageSwitcher() {
   }, []);
 
   const changeLanguage = async (lng: string) => {
+    setCurrentLang(lng);
     await i18n.changeLanguage(lng);
+    document.documentElement.lang = lng;
+    setLocaleCookie(lng);
 
     if (hasToken()) {
       try {
@@ -30,6 +39,8 @@ export default function LanguageSwitcher() {
         console.warn('Failed to update language on server:', error);
       }
     }
+
+    router.refresh();
   };
 
   return (

--- a/apps/webapp/src/components/PublicLayout.tsx
+++ b/apps/webapp/src/components/PublicLayout.tsx
@@ -1,0 +1,96 @@
+import { ReactNode } from 'react';
+import Link from 'next/link';
+import { getTranslation } from '../lib/server-i18n';
+import LanguageSwitcher from './LanguageSwitcher';
+
+interface NavigationItem {
+  label: string;
+  href: string;
+  icon?: ReactNode;
+  primary?: boolean;
+}
+
+interface PublicLayoutProps {
+  children: ReactNode;
+  locale: string;
+  navigationItems?: NavigationItem[];
+}
+
+export default function PublicLayout({
+  children,
+  locale,
+  navigationItems = [],
+}: PublicLayoutProps) {
+  const t = getTranslation(locale);
+
+  return (
+    <main className="min-h-screen bg-gray-50 text-black">
+      <nav className="container mx-auto px-6 py-6">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div className="flex items-center gap-2">
+            <img
+              src="/sentry-guard-logo.svg"
+              alt="SentryGuard Logo"
+              className="w-20 h-20"
+            />
+            <h1 className="text-2xl font-bold">SentryGuard</h1>
+          </div>
+          <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3 sm:gap-4">
+            {navigationItems.map((item, index) => (
+              <Link
+                key={index}
+                href={item.href}
+                className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-colors duration-200 w-full sm:w-auto justify-center font-medium ${
+                  item.primary
+                    ? 'bg-gray-200 hover:bg-gray-300 text-gray-900'
+                    : 'text-gray-700 hover:text-red-600'
+                }`}
+              >
+                {item.icon}
+                {t(item.label)}
+              </Link>
+            ))}
+            <LanguageSwitcher />
+            <a
+              href="https://github.com/abarghoud/SentryGuard"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-2 px-4 py-2 bg-gray-200 hover:bg-gray-300 rounded-lg transition-colors duration-200 w-full sm:w-auto justify-center"
+            >
+              <svg
+                className="w-5 h-5"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+              </svg>
+              GitHub
+            </a>
+          </div>
+        </div>
+      </nav>
+
+      {children}
+
+      <footer className="container mx-auto px-6 py-8 border-t border-gray-300">
+        <div className="text-center text-gray-700 text-sm">
+          <p>
+            {t('© {{year}} SentryGuard. All rights reserved.', {
+              year: new Date().getFullYear(),
+            })}
+          </p>
+          <p className="mt-2">
+            {t(
+              'Not affiliated with Tesla, Inc. Tesla and the Tesla logo are trademarks of Tesla, Inc.'
+            )}
+          </p>
+          <p className="mt-2">
+            {t(
+              'SentryGuard is a non-profit, open-source project developed by the community for Tesla owners.'
+            )}
+          </p>
+        </div>
+      </footer>
+    </main>
+  );
+}

--- a/apps/webapp/src/components/faq/ContactSection.tsx
+++ b/apps/webapp/src/components/faq/ContactSection.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/apps/webapp/src/components/faq/FAQCategory.tsx
+++ b/apps/webapp/src/components/faq/FAQCategory.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { FAQItemComponent, FAQItem } from './FAQItem';
+import { FAQItemComponent, TranslatedFaqItem } from './FAQItem';
 
-interface FAQCategory {
+interface TranslatedFaqCategory {
   title: string;
-  items: FAQItem[];
+  items: TranslatedFaqItem[];
 }
 
 export function FAQCategoryComponent({
@@ -11,13 +11,11 @@ export function FAQCategoryComponent({
   categoryIndex,
   openItems,
   onToggleItem,
-  renderAnswer
 }: {
-  category: FAQCategory;
+  category: TranslatedFaqCategory;
   categoryIndex: number;
   openItems: Set<string>;
   onToggleItem: (id: string) => void;
-  renderAnswer: (item: FAQItem) => React.ReactNode;
 }) {
   return (
     <div className="rounded-2xl shadow-sm border overflow-hidden bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700">
@@ -38,7 +36,6 @@ export function FAQCategoryComponent({
               itemId={itemId}
               isOpen={isOpen}
               onToggle={onToggleItem}
-              renderAnswer={renderAnswer}
             />
           );
         })}

--- a/apps/webapp/src/components/faq/FAQContent.tsx
+++ b/apps/webapp/src/components/faq/FAQContent.tsx
@@ -1,42 +1,26 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import React from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import { FAQCategoryComponent } from './FAQCategory';
 import { ContactSection } from './ContactSection';
+import { faqCategories } from '../../lib/faq-data';
 
-interface FAQItem {
-  question: string;
-  answer: string | (() => React.ReactNode);
-}
+const linkClassName =
+  'text-blue-400 hover:text-blue-300 underline transition-colors duration-200';
 
-interface FAQCategory {
-  title: string;
-  items: FAQItem[];
+function createLink(
+  href: string,
+  target = '_blank',
+  rel = 'noopener noreferrer'
+) {
+  return <a href={href} target={target} rel={rel} className={linkClassName} />;
 }
 
 export default function FAQContent() {
   const { t } = useTranslation('common');
   const [openItems, setOpenItems] = useState<Set<string>>(new Set());
-
-  const linkClassName = 'text-blue-400 hover:text-blue-300 underline transition-colors duration-200';
-
-  const createLink = (href: string, target = '_blank', rel = 'noopener noreferrer') => (
-    <a
-      href={href}
-      target={target}
-      rel={rel}
-      className={linkClassName}
-    />
-  );
-
-  const createMailtoLink = (email: string) => (
-    <a
-      href={`mailto:${email}`}
-      className={linkClassName}
-    />
-  );
 
   const toggleItem = (id: string) => {
     const newOpenItems = new Set(openItems);
@@ -48,273 +32,40 @@ export default function FAQContent() {
     setOpenItems(newOpenItems);
   };
 
-  const renderAnswer = (item: FAQItem) => {
-    if (typeof item.answer === 'function') {
-      return item.answer();
-    }
-
-    return t(item.answer);
-  };
-
-  const categories: FAQCategory[] = [
-    {
-      title: t('General Questions'),
-      items: [
-        {
-          question: t('What is SentryGuard?'),
-          answer: t('What is SentryGuard description')
-        },
-        {
-          question: t('Does Sentry Mode need to be activated to receive notifications?'),
-          answer: t('SentryGuard requires active Sentry Mode')
-        },
-        {
-          question: t('Why Telegram?'),
-          answer: t('Why we chose Telegram')
-        },
-        {
-          question: t('Why isn\'t there a mobile app?'),
-          answer: t('Why no mobile app')
-        },
-        {
-          question: t('Is SentryGuard free?'),
-          answer: t('Is SentryGuard free description')
-        },
-        {
-          question: t('Is SentryGuard affiliated with Tesla?'),
-          answer: t('Is SentryGuard affiliated with Tesla description')
-        },
-        {
-          question: t('How does SentryGuard work?'),
-          answer: t('How does SentryGuard work description')
-        },
-        {
-          question: t('Does SentryGuard provide video footage?'),
-          answer: t('SentryGuard video access explanation')
-        },
-        {
-          question: t('Why is SentryGuard faster than Tesla notifications?'),
-          answer: t('SentryGuard speed advantage explanation')
-        },
-        {
-          question: t('Do I need Tesla Premium Connectivity to use SentryGuard?'),
-          answer: t('Tesla Premium Connectivity requirement')
-        }
-      ]
-    },
-    {
-      title: t('Setup & Configuration'),
-      items: [
-        {
-          question: t('How do I get started with SentryGuard?'),
-          answer: () => (
+  const translatedCategories = useMemo(
+    () =>
+      faqCategories.map((category) => ({
+        title: t(category.titleKey),
+        items: category.items.map((item) => ({
+          question: t(item.questionKey),
+          answer: item.answerLinks ? (
             <Trans
-              i18nKey="How to get started with SentryGuard"
-              components={[
-                createLink('/dashboard/vehicles'),
-                createLink('/dashboard/telegram')
-              ]}
+              i18nKey={item.answerKey}
+              components={item.answerLinks.map((link) =>
+                createLink(link.href)
+              )}
             />
-          )
-        },
-        {
-          question: t('What permissions does SentryGuard need?'),
-          answer: t('What permissions SentryGuard needs')
-        },
-        {
-          question: t('How do I link my Telegram account?'),
-          answer: () => (
-            <Trans
-              i18nKey="How to link Telegram account"
-              components={[createLink('/dashboard/telegram')]}
-            />
-          )
-        },
-        {
-          question: t('What if I can\'t enable telemetry for my vehicle?'),
-          answer: t('Cannot enable telemetry help')
-        },
-        {
-          question: t('What is the purpose of pairing a virtual key with SentryGuard?'),
-          answer: t('Virtual key purpose explanation')
-        }
-      ]
-    },
-    {
-      title: t('Security & Privacy'),
-      items: [
-        {
-          question: t('Is my data secure?'),
-          answer: t('Is my data secure answer')
-        },
-        {
-          question: t('What data does SentryGuard collect?'),
-          answer: t('What data SentryGuard collects')
-        },
-        {
-          question: t('Can I delete my data?'),
-          answer: () => (
-            <Trans
-              i18nKey="Can I delete my data answer"
-              components={[createMailtoLink('hello@sentryguard.org')]}
-            />
-          )
-        },
-        {
-          question: t('Where is my data stored?'),
-          answer: t('Where is my data stored answer')
-        }
-      ]
-    },
-    {
-      title: t('Troubleshooting'),
-      items: [
-        {
-          question: t('I\'m not receiving Telegram alerts. What should I do?'),
-          answer: () => (
-            <Trans
-              i18nKey="Not receiving alerts help"
-              components={[
-                createLink('/dashboard/telegram'),
-                createLink('/dashboard/vehicles')
-              ]}
-            />
-          )
-        },
-        {
-          question: t('Does SentryGuard impact the vehicle\'s battery or range?'),
-          answer: t('SentryGuard battery impact')
-        },
-        {
-          question: t('Why did my Tesla authorization get revoked?'),
-          answer: t('Tesla authorization revoked help')
-        },
-        {
-          question: t('SentryGuard shows "Virtual Key Not Paired". What does this mean?'),
-          answer: () => (
-            <Trans
-              i18nKey="Virtual key not paired help"
-              components={[createLink('/dashboard/vehicles')]}
-            />
-          )
-        },
-        {
-          question: t('Why doesn\'t Sentry Mode trigger when I test it myself?'),
-          answer: t('Sentry Mode testing explanation')
-        },
-        {
-          question: t('Can I use SentryGuard with multiple vehicles?'),
-          answer: t('Multiple vehicles support')
-        },
-        {
-          question: t('Does SentryGuard work without internet connection?'),
-          answer: t('Internet connection requirement explanation')
-        },
-        {
-          question: t('Why does the app crash when I use browser translation?'),
-          answer: t('Browser translation issue explanation')
-        }
-      ]
-    },
-    {
-      title: t('Beta & Waitlist'),
-      items: [
-        {
-          question: t('Why is there a waitlist?'),
-          answer: t('Why is there a waitlist answer')
-        },
-        {
-          question: t('How long does waitlist approval take?'),
-          answer: t('How long does waitlist approval take answer')
-        },
-        {
-          question: t('What happens after I\'m approved?'),
-          answer: t('What happens after I\'m approved answer')
-        },
-        {
-          question: t('I signed up but didn\'t receive an approval email'),
-          answer: t('I signed up but didn\'t receive an approval email answer')
-        },
-        {
-          question: t('Can I check my waitlist status?'),
-          answer: t('Can I check my waitlist status answer')
-        },
-        {
-          question: t('Can I use SentryGuard while on the waitlist?'),
-          answer: t('Can I use SentryGuard while on the waitlist answer')
-        },
-        {
-          question: t('What if I try to log in before being approved?'),
-          answer: t('What if I try to log in before being approved answer')
-        },
-        {
-          question: t('When is the official launch?'),
-          answer: t('When is the official launch answer')
-        },
-        {
-          question: t('Should I wait for the launch or join the beta waitlist?'),
-          answer: t('Should I wait for the launch or join the beta waitlist answer')
-        }
-      ]
-    },
-    {
-      title: t('Support & Donations'),
-      items: [
-        {
-          question: t('How can I support SentryGuard?'),
-          answer: () => (
-            <Trans
-              i18nKey="How to support SentryGuard"
-              components={[
-                createLink('https://github.com/abarghoud/SentryGuard'),
-                createLink('https://buymeacoffee.com/sentryguardorg')
-              ]}
-            />
-          )
-        },
-        {
-          question: t('How can I report a bug or request a feature?'),
-          answer: () => (
-            <Trans
-              i18nKey="How to report bugs or request features"
-              components={[createLink('https://github.com/abarghoud/SentryGuard')]}
-            />
-          )
-        },
-        {
-          question: t('Who can I contact for support?'),
-          answer: () => (
-            <Trans
-              i18nKey="Who to contact for support"
-              components={[
-                createMailtoLink('hello@sentryguard.org'),
-                createLink('https://github.com/abarghoud/SentryGuard')
-              ]}
-            />
-          )
-        }
-      ]
-    }
-  ];
-
-  const renderFAQCategories = () => (
-    <div className="space-y-6">
-      {categories.map((category, categoryIndex) => (
-        <FAQCategoryComponent
-          key={categoryIndex}
-          category={category}
-          categoryIndex={categoryIndex}
-          openItems={openItems}
-          onToggleItem={toggleItem}
-          renderAnswer={renderAnswer}
-        />
-      ))}
-    </div>
+          ) : (
+            t(item.answerKey)
+          ),
+        })),
+      })),
+    [t]
   );
 
   return (
     <>
-      {renderFAQCategories()}
+      <div className="space-y-6">
+        {translatedCategories.map((category, categoryIndex) => (
+          <FAQCategoryComponent
+            key={categoryIndex}
+            category={category}
+            categoryIndex={categoryIndex}
+            openItems={openItems}
+            onToggleItem={toggleItem}
+          />
+        ))}
+      </div>
       <ContactSection />
     </>
   );

--- a/apps/webapp/src/components/faq/FAQItem.tsx
+++ b/apps/webapp/src/components/faq/FAQItem.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-export interface FAQItem {
+export interface TranslatedFaqItem {
   question: string;
-  answer: string | (() => React.ReactNode);
+  answer: React.ReactNode;
 }
 
 export function FAQItemComponent({
@@ -10,13 +10,11 @@ export function FAQItemComponent({
   itemId,
   isOpen,
   onToggle,
-  renderAnswer
 }: {
-  item: FAQItem;
+  item: TranslatedFaqItem;
   itemId: string;
   isOpen: boolean;
   onToggle: (id: string) => void;
-  renderAnswer: (item: FAQItem) => React.ReactNode;
 }) {
   return (
     <div className="transition-all duration-200 hover:bg-gray-50 dark:hover:bg-gray-700/50">
@@ -51,7 +49,7 @@ export function FAQItemComponent({
       >
         <div className="px-6 pb-5 pt-0">
           <p className="leading-relaxed text-sm text-gray-600 dark:text-gray-300">
-            {renderAnswer(item)}
+            {item.answer}
           </p>
         </div>
       </div>

--- a/apps/webapp/src/lib/faq-data.ts
+++ b/apps/webapp/src/lib/faq-data.ts
@@ -1,0 +1,243 @@
+export interface FaqItemData {
+  questionKey: string;
+  answerKey: string;
+  answerLinks?: Array<{ href: string }>;
+}
+
+export interface FaqCategoryData {
+  titleKey: string;
+  items: FaqItemData[];
+}
+
+export const faqCategories: FaqCategoryData[] = [
+  {
+    titleKey: 'General Questions',
+    items: [
+      {
+        questionKey: 'What is SentryGuard?',
+        answerKey: 'What is SentryGuard description',
+      },
+      {
+        questionKey:
+          'Does Sentry Mode need to be activated to receive notifications?',
+        answerKey: 'SentryGuard requires active Sentry Mode',
+      },
+      {
+        questionKey: 'Why Telegram?',
+        answerKey: 'Why we chose Telegram',
+      },
+      {
+        questionKey: "Why isn't there a mobile app?",
+        answerKey: 'Why no mobile app',
+      },
+      {
+        questionKey: 'Is SentryGuard free?',
+        answerKey: 'Is SentryGuard free description',
+      },
+      {
+        questionKey: 'Is SentryGuard affiliated with Tesla?',
+        answerKey: 'Is SentryGuard affiliated with Tesla description',
+      },
+      {
+        questionKey: 'How does SentryGuard work?',
+        answerKey: 'How does SentryGuard work description',
+      },
+      {
+        questionKey: 'Does SentryGuard provide video footage?',
+        answerKey: 'SentryGuard video access explanation',
+      },
+      {
+        questionKey:
+          'Why is SentryGuard faster than Tesla notifications?',
+        answerKey: 'SentryGuard speed advantage explanation',
+      },
+      {
+        questionKey:
+          'Do I need Tesla Premium Connectivity to use SentryGuard?',
+        answerKey: 'Tesla Premium Connectivity requirement',
+      },
+    ],
+  },
+  {
+    titleKey: 'Setup & Configuration',
+    items: [
+      {
+        questionKey: 'How do I get started with SentryGuard?',
+        answerKey: 'How to get started with SentryGuard',
+        answerLinks: [
+          { href: '/dashboard/vehicles' },
+          { href: '/dashboard/telegram' },
+        ],
+      },
+      {
+        questionKey: 'What permissions does SentryGuard need?',
+        answerKey: 'What permissions SentryGuard needs',
+      },
+      {
+        questionKey: 'How do I link my Telegram account?',
+        answerKey: 'How to link Telegram account',
+        answerLinks: [{ href: '/dashboard/telegram' }],
+      },
+      {
+        questionKey:
+          "What if I can't enable telemetry for my vehicle?",
+        answerKey: 'Cannot enable telemetry help',
+      },
+      {
+        questionKey:
+          'What is the purpose of pairing a virtual key with SentryGuard?',
+        answerKey: 'Virtual key purpose explanation',
+      },
+    ],
+  },
+  {
+    titleKey: 'Security & Privacy',
+    items: [
+      {
+        questionKey: 'Is my data secure?',
+        answerKey: 'Is my data secure answer',
+      },
+      {
+        questionKey: 'What data does SentryGuard collect?',
+        answerKey: 'What data SentryGuard collects',
+      },
+      {
+        questionKey: 'Can I delete my data?',
+        answerKey: 'Can I delete my data answer',
+        answerLinks: [{ href: 'mailto:hello@sentryguard.org' }],
+      },
+      {
+        questionKey: 'Where is my data stored?',
+        answerKey: 'Where is my data stored answer',
+      },
+    ],
+  },
+  {
+    titleKey: 'Troubleshooting',
+    items: [
+      {
+        questionKey:
+          "I'm not receiving Telegram alerts. What should I do?",
+        answerKey: 'Not receiving alerts help',
+        answerLinks: [
+          { href: '/dashboard/telegram' },
+          { href: '/dashboard/vehicles' },
+        ],
+      },
+      {
+        questionKey:
+          "Does SentryGuard impact the vehicle's battery or range?",
+        answerKey: 'SentryGuard battery impact',
+      },
+      {
+        questionKey:
+          'Why did my Tesla authorization get revoked?',
+        answerKey: 'Tesla authorization revoked help',
+      },
+      {
+        questionKey:
+          'SentryGuard shows "Virtual Key Not Paired". What does this mean?',
+        answerKey: 'Virtual key not paired help',
+        answerLinks: [{ href: '/dashboard/vehicles' }],
+      },
+      {
+        questionKey:
+          "Why doesn't Sentry Mode trigger when I test it myself?",
+        answerKey: 'Sentry Mode testing explanation',
+      },
+      {
+        questionKey:
+          'Can I use SentryGuard with multiple vehicles?',
+        answerKey: 'Multiple vehicles support',
+      },
+      {
+        questionKey:
+          'Does SentryGuard work without internet connection?',
+        answerKey: 'Internet connection requirement explanation',
+      },
+      {
+        questionKey:
+          'Why does the app crash when I use browser translation?',
+        answerKey: 'Browser translation issue explanation',
+      },
+    ],
+  },
+  {
+    titleKey: 'Beta & Waitlist',
+    items: [
+      {
+        questionKey: 'Why is there a waitlist?',
+        answerKey: 'Why is there a waitlist answer',
+      },
+      {
+        questionKey: 'How long does waitlist approval take?',
+        answerKey: 'How long does waitlist approval take answer',
+      },
+      {
+        questionKey: "What happens after I'm approved?",
+        answerKey: "What happens after I'm approved answer",
+      },
+      {
+        questionKey:
+          "I signed up but didn't receive an approval email",
+        answerKey:
+          "I signed up but didn't receive an approval email answer",
+      },
+      {
+        questionKey: 'Can I check my waitlist status?',
+        answerKey: 'Can I check my waitlist status answer',
+      },
+      {
+        questionKey:
+          'Can I use SentryGuard while on the waitlist?',
+        answerKey:
+          'Can I use SentryGuard while on the waitlist answer',
+      },
+      {
+        questionKey:
+          'What if I try to log in before being approved?',
+        answerKey:
+          'What if I try to log in before being approved answer',
+      },
+      {
+        questionKey: 'When is the official launch?',
+        answerKey: 'When is the official launch answer',
+      },
+      {
+        questionKey:
+          'Should I wait for the launch or join the beta waitlist?',
+        answerKey:
+          'Should I wait for the launch or join the beta waitlist answer',
+      },
+    ],
+  },
+  {
+    titleKey: 'Support & Donations',
+    items: [
+      {
+        questionKey: 'How can I support SentryGuard?',
+        answerKey: 'How to support SentryGuard',
+        answerLinks: [
+          { href: 'https://github.com/abarghoud/SentryGuard' },
+          { href: 'https://buymeacoffee.com/sentryguardorg' },
+        ],
+      },
+      {
+        questionKey:
+          'How can I report a bug or request a feature?',
+        answerKey: 'How to report bugs or request features',
+        answerLinks: [
+          { href: 'https://github.com/abarghoud/SentryGuard' },
+        ],
+      },
+      {
+        questionKey: 'Who can I contact for support?',
+        answerKey: 'Who to contact for support',
+        answerLinks: [
+          { href: 'mailto:hello@sentryguard.org' },
+          { href: 'https://github.com/abarghoud/SentryGuard' },
+        ],
+      },
+    ],
+  },
+];

--- a/apps/webapp/src/lib/server-i18n.tsx
+++ b/apps/webapp/src/lib/server-i18n.tsx
@@ -1,0 +1,92 @@
+import { cookies, headers } from 'next/headers';
+import { ReactNode } from 'react';
+
+import en from '../locales/en/common.json';
+import fr from '../locales/fr/common.json';
+
+const translations: Record<string, Record<string, string>> = { en, fr };
+
+export async function getLocale(): Promise<string> {
+  const cookieStore = await cookies();
+  const localeCookie = cookieStore.get('locale');
+
+  if (localeCookie?.value && translations[localeCookie.value]) {
+    return localeCookie.value;
+  }
+
+  const headerStore = await headers();
+  const acceptLanguage = headerStore.get('accept-language') || '';
+
+  if (acceptLanguage.toLowerCase().startsWith('fr')) {
+    return 'fr';
+  }
+
+  return 'en';
+}
+
+export function getTranslation(locale: string) {
+  const dict = translations[locale] || translations['en'];
+
+  return (key: string, params?: Record<string, string | number>): string => {
+    let value = dict[key] || key;
+
+    if (params) {
+      Object.entries(params).forEach(([k, v]) => {
+        value = value.replaceAll(`{{${k}}}`, String(v));
+      });
+    }
+
+    return value;
+  };
+}
+
+export function renderRichTranslation(
+  text: string,
+  links: Array<{ href: string }>
+): ReactNode[] {
+  const result: ReactNode[] = [];
+  let lastIndex = 0;
+  const regex = /<(\d+)>(.*?)<\/\1>/g;
+  let match;
+  let keyIndex = 0;
+
+  while ((match = regex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      result.push(text.slice(lastIndex, match.index));
+    }
+
+    const linkIndex = parseInt(match[1]);
+    const linkText = match[2];
+    const link = links[linkIndex];
+
+    if (link) {
+      const isExternal =
+        link.href.startsWith('http') || link.href.startsWith('mailto:');
+      result.push(
+        <a
+          key={keyIndex++}
+          href={link.href}
+          target={isExternal ? '_blank' : undefined}
+          rel={isExternal ? 'noopener noreferrer' : undefined}
+          className="text-blue-600 hover:text-blue-800 underline transition-colors duration-200"
+        >
+          {linkText}
+        </a>
+      );
+    } else {
+      result.push(linkText);
+    }
+
+    lastIndex = regex.lastIndex;
+  }
+
+  if (lastIndex < text.length) {
+    result.push(text.slice(lastIndex));
+  }
+
+  return result;
+}
+
+export function stripRichTextTags(text: string): string {
+  return text.replace(/<\d+>(.*?)<\/\d+>/g, '$1');
+}

--- a/apps/webapp/tsconfig.json
+++ b/apps/webapp/tsconfig.json
@@ -30,6 +30,7 @@
     "src/**/*.jsx",
     "src/**/*.ts",
     "src/**/*.tsx",
+    "src/**/*.json",
     ".next/types/**/*.ts",
     "src/**/*.test.ts",
     "src/**/*.test.tsx",


### PR DESCRIPTION
Closes #91 

- Render landing and FAQ pages as Server Components for SEO                      
- Add server-side locale detection via cookie and Accept-Language header
- Fix hydration errors by deferring third-party scripts (Crisp, BMC)
- Fix i18n race condition between I18nProvider and LanguageSwitcher
- Deduplicate FAQ data into single source (faq-data.ts)
- Add JSON-LD structured data for FAQ rich snippets
