### PR TITLE
fix: suppress false positive break-in alerts during charge port interaction

### DIFF
--- a/apps/api/src/app/alerts/break-in/break-in-alert-handler.service.spec.ts
+++ b/apps/api/src/app/alerts/break-in/break-in-alert-handler.service.spec.ts
@@ -4,7 +4,8 @@ import { BreakInAlertHandlerService } from './break-in-alert-handler.service';
 import { TelegramService } from '../../telegram/telegram.service';
 import { TelegramKeyboardBuilderService } from '../../telegram/telegram-keyboard-builder.service';
 import { VehicleAlertNotifierService } from '../common/vehicle-alert-notifier.service';
-import { TelemetryMessage } from '../../telemetry/models/telemetry-message.model';
+import { TelemetryMessage, TelemetryDatum } from '../../telemetry/models/telemetry-message.model';
+import { ChargePortLatchTrackerService } from './charge-port-latch-tracker.service';
 
 describe('The BreakInAlertHandlerService class', () => {
   let service: BreakInAlertHandlerService;
@@ -12,11 +13,13 @@ describe('The BreakInAlertHandlerService class', () => {
   let mockTelegramService: MockProxy<TelegramService>;
   let mockKeyboardBuilder: MockProxy<TelegramKeyboardBuilderService>;
   let mockAlertNotifier: MockProxy<VehicleAlertNotifierService>;
+  let mockChargeTracker: MockProxy<ChargePortLatchTrackerService>;
 
   beforeEach(async () => {
     mockTelegramService = mock<TelegramService>();
     mockKeyboardBuilder = mock<TelegramKeyboardBuilderService>();
     mockAlertNotifier = mock<VehicleAlertNotifierService>();
+    mockChargeTracker = mock<ChargePortLatchTrackerService>();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -24,24 +27,51 @@ describe('The BreakInAlertHandlerService class', () => {
         { provide: TelegramService, useValue: mockTelegramService },
         { provide: TelegramKeyboardBuilderService, useValue: mockKeyboardBuilder },
         { provide: VehicleAlertNotifierService, useValue: mockAlertNotifier },
+        { provide: ChargePortLatchTrackerService, useValue: mockChargeTracker },
       ],
     }).compile();
 
     service = module.get<BreakInAlertHandlerService>(BreakInAlertHandlerService);
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   describe('The handle() method', () => {
+    describe('When message contains a ChargePortLatch event', () => {
+      let message: TelemetryMessage;
+
+      beforeEach(() => {
+        message = new TelemetryMessage();
+        message.vin = '123';
+        message.createdAt = new Date('2026-05-05T20:00:00Z').toISOString();
+        message.data = [{ key: 'ChargePortLatch' } as TelemetryDatum];
+        jest.spyOn(message, 'validateContainsCenterDisplay').mockReturnValue(false);
+      });
+
+      it('should track the latch event in the charge tracker', async () => {
+        await service.handle(message);
+        const expectedTime = new Date(message.createdAt).getTime();
+        expect(mockChargeTracker.trackLatchEvent).toHaveBeenCalledWith('123', expectedTime);
+      });
+    });
+
     describe('When message does not contain CenterDisplay data', () => {
       let message: TelemetryMessage;
 
       beforeEach(() => {
         message = new TelemetryMessage();
         message.vin = '123';
+        message.createdAt = new Date('2026-05-05T20:00:00Z').toISOString();
+        message.data = [];
         jest.spyOn(message, 'validateContainsCenterDisplay').mockReturnValue(false);
       });
 
       it('should not dispatch alert', async () => {
         await service.handle(message);
+        jest.runAllTimers();
         expect(mockAlertNotifier.dispatch).not.toHaveBeenCalled();
       });
     });
@@ -52,29 +82,64 @@ describe('The BreakInAlertHandlerService class', () => {
       beforeEach(() => {
         message = new TelemetryMessage();
         message.vin = '123';
+        message.createdAt = new Date('2026-05-05T20:00:00Z').toISOString();
+        message.data = [];
         jest.spyOn(message, 'validateContainsCenterDisplay').mockReturnValue(true);
         jest.spyOn(message, 'isCenterDisplayLocked').mockReturnValue(false);
       });
 
       it('should not dispatch alert', async () => {
         await service.handle(message);
+        jest.runAllTimers();
         expect(mockAlertNotifier.dispatch).not.toHaveBeenCalled();
       });
     });
 
-    describe('When displayState is DisplayStateLock', () => {
+    describe('When displayState is DisplayStateLock and a recent latch event occurred', () => {
       let message: TelemetryMessage;
 
       beforeEach(() => {
         message = new TelemetryMessage();
         message.vin = '123';
+        message.createdAt = new Date('2026-05-05T20:00:00Z').toISOString();
+        message.data = [];
         jest.spyOn(message, 'validateContainsCenterDisplay').mockReturnValue(true);
         jest.spyOn(message, 'isCenterDisplayLocked').mockReturnValue(true);
+        mockChargeTracker.hasLatchEventAround.mockReturnValue(true);
       });
 
-      it('should dispatch alert via alertNotifier', async () => {
+      it('should delay the verification by 3 seconds to ensure subsequent ChargePortLatch events have time to arrive, then prevent alert dispatch', async () => {
         await service.handle(message);
-        
+        jest.advanceTimersByTime(3000);
+
+        await Promise.resolve();
+
+        expect(mockChargeTracker.hasLatchEventAround).toHaveBeenCalled();
+        expect(mockAlertNotifier.dispatch).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('When displayState is DisplayStateLock and no recent latch event occurred', () => {
+      let message: TelemetryMessage;
+
+      beforeEach(() => {
+        message = new TelemetryMessage();
+        message.vin = '123';
+        message.createdAt = new Date('2026-05-05T20:00:00Z').toISOString();
+        message.data = [];
+        jest.spyOn(message, 'validateContainsCenterDisplay').mockReturnValue(true);
+        jest.spyOn(message, 'isCenterDisplayLocked').mockReturnValue(true);
+        mockChargeTracker.hasLatchEventAround.mockReturnValue(false);
+      });
+
+      it('should delay the verification by 3 seconds to account for telemetry lag, then dispatch the alert via alertNotifier', async () => {
+        await service.handle(message);
+        expect(mockAlertNotifier.dispatch).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(3000);
+
+        await Promise.resolve();
+
         expect(mockAlertNotifier.dispatch).toHaveBeenCalledWith(expect.objectContaining({
           telemetryMessage: message,
           alertName: 'BREAK_IN_ALERT',
@@ -85,6 +150,8 @@ describe('The BreakInAlertHandlerService class', () => {
 
       it('should construct and send telegram message when notifier callback is invoked', async () => {
         await service.handle(message);
+        jest.advanceTimersByTime(3000);
+        await Promise.resolve();
 
         const dispatchCall = mockAlertNotifier.dispatch.mock.calls[0][0];
         const notifierCb = dispatchCall.telegramNotifier;

--- a/apps/api/src/app/alerts/break-in/break-in-alert-handler.service.ts
+++ b/apps/api/src/app/alerts/break-in/break-in-alert-handler.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 
 import { TelegramService } from '../../telegram/telegram.service';
 import { TelegramKeyboardBuilderService } from '../../telegram/telegram-keyboard-builder.service';
@@ -6,26 +6,60 @@ import { TelemetryEventHandler } from '../../telemetry/interfaces/telemetry-even
 import { TelemetryMessage } from '../../telemetry/models/telemetry-message.model';
 import { VehicleAlertNotifierService } from '../common/vehicle-alert-notifier.service';
 
+import { ChargePortLatchTrackerService } from './charge-port-latch-tracker.service';
+
 @Injectable()
 export class BreakInAlertHandlerService implements TelemetryEventHandler {
+  private readonly logger = new Logger(BreakInAlertHandlerService.name);
+
   constructor(
     private readonly telegramService: TelegramService,
     private readonly keyboardBuilder: TelegramKeyboardBuilderService,
-    private readonly alertNotifier: VehicleAlertNotifierService
+    private readonly alertNotifier: VehicleAlertNotifierService,
+    private readonly chargeTracker: ChargePortLatchTrackerService
   ) { }
 
-  async handle(telemetryMessage: TelemetryMessage): Promise<void> {
+  public async handle(telemetryMessage: TelemetryMessage): Promise<void> {
+    this.trackChargePortEvents(telemetryMessage);
+
     if (!telemetryMessage.validateContainsCenterDisplay()) {
       return;
     }
 
     if (telemetryMessage.isCenterDisplayLocked()) {
+      this.scheduleAlertVerification(telemetryMessage);
+    }
+  }
+
+  private trackChargePortEvents(telemetryMessage: TelemetryMessage): void {
+    if (telemetryMessage.data.some(d => d.key === 'ChargePortLatch')) {
+      const eventTime = new Date(telemetryMessage.createdAt).getTime();
+      this.chargeTracker.trackLatchEvent(telemetryMessage.vin, eventTime);
+    }
+  }
+
+  private scheduleAlertVerification(telemetryMessage: TelemetryMessage): void {
+    setTimeout(async () => {
+      await this.verifyAndDispatchAlert(telemetryMessage);
+    }, 3000);
+  }
+
+  private async verifyAndDispatchAlert(telemetryMessage: TelemetryMessage): Promise<void> {
+    try {
+      const eventTime = new Date(telemetryMessage.createdAt).getTime();
+      if (this.chargeTracker.hasLatchEventAround(telemetryMessage.vin, eventTime)) {
+        this.logger.log(`[False Positive Prevented] Suppressing break-in alert for VIN ${telemetryMessage.vin} due to correlated ChargePortLatch event.`);
+        return;
+      }
+
       await this.alertNotifier.dispatch({
         telemetryMessage,
         alertName: 'BREAK_IN_ALERT',
         latencyLabel: 'BREAK_IN_LATENCY',
         telegramNotifier: this.telegramNotifier
       });
+    } catch (error) {
+      this.logger.error('Failed to dispatch delayed break-in alert:', error);
     }
   }
 

--- a/apps/api/src/app/alerts/break-in/charge-port-latch-tracker.service.spec.ts
+++ b/apps/api/src/app/alerts/break-in/charge-port-latch-tracker.service.spec.ts
@@ -1,0 +1,93 @@
+import { ChargePortLatchTrackerService } from './charge-port-latch-tracker.service';
+
+describe('The ChargePortLatchTrackerService class', () => {
+  let service: ChargePortLatchTrackerService;
+  const fakeVin = 'fake-vin';
+  const baseTimestamp = 1000000;
+
+  beforeEach(() => {
+    service = new ChargePortLatchTrackerService();
+    jest.useFakeTimers();
+    jest.setSystemTime(baseTimestamp);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('The trackLatchEvent() method', () => {
+    describe('When tracking a single event', () => {
+      beforeEach(() => {
+        service.trackLatchEvent(fakeVin, baseTimestamp);
+      });
+
+      it('should store the event and make it available for checking', () => {
+        const hasEvent = service.hasLatchEventAround(fakeVin, baseTimestamp);
+        expect(hasEvent).toStrictEqual(true);
+      });
+    });
+
+    describe('When tracking an event older than CLEANUP_MS', () => {
+      beforeEach(() => {
+        service.trackLatchEvent(fakeVin, baseTimestamp - 20000);
+      });
+
+      it('should clean up the old event', () => {
+        const hasEvent = service.hasLatchEventAround(fakeVin, baseTimestamp);
+        expect(hasEvent).toStrictEqual(false);
+      });
+    });
+  });
+
+  describe('The hasLatchEventAround() method', () => {
+    describe('When an event exists exactly at the given timestamp', () => {
+      beforeEach(() => {
+        service.trackLatchEvent(fakeVin, baseTimestamp);
+      });
+
+      it('should return true', () => {
+        expect(service.hasLatchEventAround(fakeVin, baseTimestamp)).toStrictEqual(true);
+      });
+    });
+
+    describe('When an event exists within WINDOW_MS before the timestamp', () => {
+      beforeEach(() => {
+        service.trackLatchEvent(fakeVin, baseTimestamp - 4000);
+      });
+
+      it('should return true', () => {
+        expect(service.hasLatchEventAround(fakeVin, baseTimestamp)).toStrictEqual(true);
+      });
+    });
+
+    describe('When an event exists within WINDOW_MS after the timestamp', () => {
+      beforeEach(() => {
+        service.trackLatchEvent(fakeVin, baseTimestamp + 4000);
+      });
+
+      it('should return true', () => {
+        expect(service.hasLatchEventAround(fakeVin, baseTimestamp)).toStrictEqual(true);
+      });
+    });
+
+    describe('When an event exists outside WINDOW_MS', () => {
+      beforeEach(() => {
+        service.trackLatchEvent(fakeVin, baseTimestamp - 6000);
+      });
+
+      it('should return false', () => {
+        expect(service.hasLatchEventAround(fakeVin, baseTimestamp)).toStrictEqual(false);
+      });
+    });
+
+    describe('When no events exist for the given vin', () => {
+      beforeEach(() => {
+        service.trackLatchEvent('other-vin', baseTimestamp);
+      });
+
+      it('should return false', () => {
+        expect(service.hasLatchEventAround(fakeVin, baseTimestamp)).toStrictEqual(false);
+      });
+    });
+  });
+});

--- a/apps/api/src/app/alerts/break-in/charge-port-latch-tracker.service.ts
+++ b/apps/api/src/app/alerts/break-in/charge-port-latch-tracker.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ChargePortLatchTrackerService {
+  private readonly WINDOW_MS = 5000;
+  private readonly CLEANUP_MS = 15000;
+
+  private recentEvents = new Map<string, number[]>();
+
+  trackLatchEvent(vin: string, timestamp: number): void {
+    const events = this.recentEvents.get(vin) || [];
+    events.push(timestamp);
+
+    this.recentEvents.set(vin, events.filter(t => timestamp - t < this.CLEANUP_MS));
+  }
+
+  hasLatchEventAround(vin: string, eventTimestamp: number): boolean {
+    const events = this.recentEvents.get(vin) || [];
+
+    const hasEvent = events.some(t => Math.abs(eventTimestamp - t) <= this.WINDOW_MS);
+
+    const now = Date.now();
+    this.recentEvents.set(vin, events.filter(t => now - t < this.CLEANUP_MS));
+
+    return hasEvent;
+  }
+}

--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -11,6 +11,7 @@ import { TelemetryMessageHandlerService } from './telemetry/handlers/telemetry-m
 import { TelemetryValidationService } from './telemetry/services/telemetry-validation.service';
 import { SentryAlertHandlerService } from './alerts/sentry/sentry-alert-handler.service';
 import { BreakInAlertHandlerService } from './alerts/break-in/break-in-alert-handler.service';
+import { ChargePortLatchTrackerService } from './alerts/break-in/charge-port-latch-tracker.service';
 import { VehicleAlertNotifierService } from './alerts/common/vehicle-alert-notifier.service';
 import { TelemetryEventHandlerSymbol } from './telemetry/interfaces/telemetry-event-handler.interface';
 import { kafkaMessageHandler } from './messaging/kafka/interfaces/message-handler.interface';
@@ -66,6 +67,7 @@ import { RetryManager } from './shared/retry-manager.service';
     VehicleAlertNotifierService,
     SentryAlertHandlerService,
     BreakInAlertHandlerService,
+    ChargePortLatchTrackerService,
     {
       provide: kafkaMessageHandler,
       useClass: TelemetryMessageHandlerService,

--- a/apps/api/src/app/telemetry/break-in-monitoring-config.service.spec.ts
+++ b/apps/api/src/app/telemetry/break-in-monitoring-config.service.spec.ts
@@ -55,10 +55,14 @@ describe('The BreakInMonitoringConfigService class', () => {
       it('should patch to add CenterDisplay with interval', async () => {
         const result = await service.toggleBreakInMonitoring(vin, userId, true);
 
+        const expectedInterval = parseInt(process.env.BREAK_IN_MONITORING_INTERVAL_SECONDS ?? String(TELEMETRY_CONFIG.DEFAULT_BREAK_IN_MONITORING_INTERVAL), 10);
         expect(mockTelemetryConfigService.patchTelemetryConfig).toHaveBeenCalledWith(
           vin,
           userId,
-          { CenterDisplay: { interval_seconds: parseInt(process.env.BREAK_IN_MONITORING_INTERVAL_SECONDS ?? String(TELEMETRY_CONFIG.DEFAULT_BREAK_IN_MONITORING_INTERVAL), 10) } },
+          {
+            CenterDisplay: { interval_seconds: expectedInterval },
+            ChargePortLatch: { interval_seconds: expectedInterval }
+          },
           []
         );
         expect(vehicle.break_in_monitoring_enabled).toBe(true);

--- a/apps/api/src/app/telemetry/break-in-monitoring-config.service.ts
+++ b/apps/api/src/app/telemetry/break-in-monitoring-config.service.ts
@@ -36,6 +36,7 @@ export class BreakInMonitoringConfigService {
           10
         );
         fieldsToUpsert['CenterDisplay'] = { interval_seconds: breakInIntervalSeconds };
+        fieldsToUpsert['ChargePortLatch'] = { interval_seconds: breakInIntervalSeconds };
       } else {
         fieldsToDelete.push('CenterDisplay');
       }

--- a/scripts/send-interactive.sh
+++ b/scripts/send-interactive.sh
@@ -66,9 +66,41 @@ echo " 15) DisplayStateSentry      # 👁️ Sentry"
 echo " 16) DisplayStateDog         # 🐶 Dog"
 echo " 17) DisplayStateEntertainment # 🎮 Entertainment"
 echo ""
+echo "Special Scenarios:"
+echo " 18) False Positive Charge Port # ⚡ Simulates CenterDisplay=Lock followed by ChargePortLatch=Disengaged"
+echo ""
 
 # Ask for state
-read -p "Choose state (1-17, or Enter for alert): " CHOICE
+read -p "Choose state (1-18, or Enter for alert): " CHOICE
+
+if [ "$CHOICE" = "18" ]; then
+    echo ""
+    echo "📤 Sending Scenario: False Positive Charge Port..."
+    echo "   VIN: $VIN"
+    
+    # 1. Send CenterDisplay=Lock
+    echo "   Step 1: Sending CenterDisplay = DisplayStateLock"
+    printf '{"vin":"%s","createdAt":"%s","isResend":false,"data":[{"key":"CenterDisplay","value":{"stringValue":"DisplayStateLock"}}]}' \
+      "$VIN" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" | \
+    $DOCKER_COMPOSE_CMD exec -T kafka kafka-console-producer \
+      --bootstrap-server localhost:9092 \
+      --topic TeslaLogger_V
+      
+    echo "   Waiting 1 second to simulate telemetry lag..."
+    sleep 1
+    
+    # 2. Send ChargePortLatch=Disengaged
+    echo "   Step 2: Sending ChargePortLatch = ChargePortLatchDisengaged"
+    printf '{"vin":"%s","createdAt":"%s","isResend":false,"data":[{"key":"ChargePortLatch","value":{"chargePortLatchValue":"ChargePortLatchDisengaged"}}]}' \
+      "$VIN" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" | \
+    $DOCKER_COMPOSE_CMD exec -T kafka kafka-console-producer \
+      --bootstrap-server localhost:9092 \
+      --topic TeslaLogger_V
+      
+    echo ""
+    echo "✅ Scenario sent successfully! The Break-in alert should NOT be dispatched."
+    exit 0
+fi
 
 # Set defaults for SentryMode
 KEY="SentryMode"


### PR DESCRIPTION
When a user presses the charging cable button, the Tesla firmware briefly emits a `CenterDisplay = Lock` signal before the `ChargePortLatch` disengages.
This `CenterDisplay = Lock` previously triggered false-positive break-in alerts.

This could be fixed in this PR. Here's what has been done:
- Implemented `ChargePortLatchTrackerService` to track latch events in RAM (TTL 15s)
- Added a non-blocking 3s delay in `BreakInAlertHandlerService` to correlate delayed latch events before dispatching alerts
- Reduced Fleet API signal subscriptions in config to only `CenterDisplay` and `ChargePortLatch` to optimize costs
- Added explicit observability logs when false-positive alerts are prevented
- Added scenario 18 to `send-interactive.sh` to simulate this edge case
- Covered new logic with unit tests

I will perform some tests myself with this fix and let some beta users who have been encountering this issue try it. If it really resolves the issue, it would be very good news for #105, because we could then implement automatic ripost while being sure no false positives would occur.