### PR TITLE
fix(api): resolve telemetry config sync bug and handle Sentry Mode toggle independently

### DIFF
--- a/apps/api/src/app/telemetry/break-in-monitoring-config.service.spec.ts
+++ b/apps/api/src/app/telemetry/break-in-monitoring-config.service.spec.ts
@@ -80,14 +80,14 @@ describe('The BreakInMonitoringConfigService class', () => {
         mockTelemetryConfigService.patchTelemetryConfig.mockResolvedValue({ success: true });
       });
 
-      it('should patch to delete CenterDisplay', async () => {
+      it('should patch to delete CenterDisplay and ChargePortLatch', async () => {
         const result = await service.toggleBreakInMonitoring(vin, userId, false);
 
         expect(mockTelemetryConfigService.patchTelemetryConfig).toHaveBeenCalledWith(
           vin,
           userId,
           {},
-          ['CenterDisplay']
+          ['CenterDisplay', 'ChargePortLatch']
         );
         expect(vehicle.break_in_monitoring_enabled).toBe(false);
         expect(mockVehicleRepository.save).toHaveBeenCalledWith(vehicle);

--- a/apps/api/src/app/telemetry/break-in-monitoring-config.service.ts
+++ b/apps/api/src/app/telemetry/break-in-monitoring-config.service.ts
@@ -39,6 +39,7 @@ export class BreakInMonitoringConfigService {
         fieldsToUpsert['ChargePortLatch'] = { interval_seconds: breakInIntervalSeconds };
       } else {
         fieldsToDelete.push('CenterDisplay');
+        fieldsToDelete.push('ChargePortLatch');
       }
 
       const result = await this.telemetryConfigService.patchTelemetryConfig(

--- a/apps/api/src/app/telemetry/telemetry-config.service.spec.ts
+++ b/apps/api/src/app/telemetry/telemetry-config.service.spec.ts
@@ -129,7 +129,7 @@ describe('TelemetryConfigService', () => {
               config: {
                 hostname: 'h',
                 ca: 'c',
-                fields: {},
+                fields: { SentryMode: { interval_seconds: 30 } },
               },
             }
             : {
@@ -193,6 +193,7 @@ describe('TelemetryConfigService', () => {
           vin: 'VIN123',
           display_name: 'Tesla Model 3',
           sentry_mode_monitoring_enabled: false,
+          break_in_monitoring_enabled: false,
         },
         { conflictPaths: ['userId', 'vin'], skipUpdateIfNoValuesChanged: true }
       );
@@ -223,6 +224,7 @@ describe('TelemetryConfigService', () => {
           vin: 'VIN123',
           display_name: 'Updated Name',
           sentry_mode_monitoring_enabled: false,
+          break_in_monitoring_enabled: false,
         },
         { conflictPaths: ['userId', 'vin'], skipUpdateIfNoValuesChanged: true }
       );
@@ -238,7 +240,7 @@ describe('TelemetryConfigService', () => {
           data: { response: mockVehicles },
         })
         .mockResolvedValueOnce({
-          data: { response: { config: { hostname: 'test.com' } } },
+          data: { response: { config: { hostname: 'test.com', fields: { SentryMode: { interval_seconds: 30 } } } } },
         });
 
       mockVehicleRepository.find.mockResolvedValue([
@@ -253,6 +255,7 @@ describe('TelemetryConfigService', () => {
           vin: 'VIN123',
           display_name: 'Tesla Model 3',
           sentry_mode_monitoring_enabled: true,
+          break_in_monitoring_enabled: false,
         },
         { conflictPaths: ['userId', 'vin'], skipUpdateIfNoValuesChanged: true }
       );
@@ -336,6 +339,7 @@ describe('TelemetryConfigService', () => {
       const userId = 'test-user-id';
       const userToken = 'user-access-token';
 
+      mockVehicleRepository.findOne.mockResolvedValueOnce(null);
       mockAccessTokenService.getAccessTokenForUserId.mockResolvedValue(userToken);
       mockAxiosInstance.delete.mockResolvedValueOnce({
         data: { success: true },
@@ -354,9 +358,40 @@ describe('TelemetryConfigService', () => {
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith(
         `/api/1/vehicles/${vin}/fleet_telemetry_config`,
         expect.objectContaining({
-          headers: { Authorization: `Bearer ${userToken}` },
+          headers: { Authorization: 'Bearer user-access-token' },
         })
       );
+      expect(updateSpy).toHaveBeenCalledWith(userId, vin, false);
+    });
+
+    it('should only patch out SentryMode if break_in_monitoring_enabled is true', async () => {
+      const vin = 'VIN123';
+      const userId = 'test-user-id';
+      const vehicle = { vin, userId, break_in_monitoring_enabled: true };
+
+      mockVehicleRepository.findOne.mockResolvedValueOnce(vehicle);
+
+      const patchSpy = jest
+        .spyOn(service, 'patchTelemetryConfig')
+        .mockResolvedValueOnce({ success: true });
+
+      const updateSpy = jest
+        .spyOn(service, 'updateVehicleTelemetryStatus')
+        .mockResolvedValueOnce(undefined);
+
+      const result = await service.deleteTelemetryConfig(vin, userId);
+
+      expect(result).toEqual({
+        success: true,
+        message: 'Telemetry configuration deleted successfully',
+      });
+      expect(patchSpy).toHaveBeenCalledWith(
+        vin,
+        userId,
+        {},
+        ['SentryMode']
+      );
+      expect(mockAxiosInstance.delete).not.toHaveBeenCalled();
       expect(updateSpy).toHaveBeenCalledWith(userId, vin, false);
     });
 

--- a/apps/api/src/app/telemetry/telemetry-config.service.ts
+++ b/apps/api/src/app/telemetry/telemetry-config.service.ts
@@ -145,18 +145,21 @@ export class TelemetryConfigService {
       );
       telemetryConfigsMap.set(teslaVehicle.vin, telemetryConfig);
 
-      const isTelemetryConfigured = telemetryConfig?.config !== null && telemetryConfig?.config !== undefined;
+      const fields = telemetryConfig?.config?.fields ?? {};
+      const isSentryModeConfigured = 'SentryMode' in fields;
+      const isBreakInConfigured = 'CenterDisplay' in fields;
 
       await this.vehicleRepository.upsert(
         {
           userId,
           vin: teslaVehicle.vin,
           display_name: teslaVehicle.display_name ?? teslaVehicle.vin,
-          sentry_mode_monitoring_enabled: isTelemetryConfigured,
+          sentry_mode_monitoring_enabled: isSentryModeConfigured,
+          break_in_monitoring_enabled: isBreakInConfigured,
         },
         { conflictPaths: ['userId', 'vin'], skipUpdateIfNoValuesChanged: true }
       );
-      this.logger.log(SUCCESS_MESSAGES.VEHICLE_UPDATED(teslaVehicle.vin, isTelemetryConfigured));
+      this.logger.log(SUCCESS_MESSAGES.VEHICLE_UPDATED(teslaVehicle.vin, isSentryModeConfigured));
     }
 
     return telemetryConfigsMap;
@@ -200,7 +203,7 @@ export class TelemetryConfigService {
       }
 
       if (Object.keys(configPayload.fields).length === 0) {
-        await this.deleteTelemetryConfig(vin, userId);
+        await this.deleteTelemetryConfig(vin, userId, true);
         return { success: true, skippedVehicle: null, response: { response: {} } } as unknown as ConfigureTelemetryResult;
       }
 
@@ -256,9 +259,31 @@ export class TelemetryConfigService {
 
   async deleteTelemetryConfig(
     vin: string,
-    userId: string
+    userId: string,
+    forceDeleteAll = false
   ): Promise<DeleteTelemetryConfigResponse> {
     try {
+      const vehicle = await this.vehicleRepository.findOne({
+        where: { userId, vin },
+      });
+
+      if (!forceDeleteAll && vehicle?.break_in_monitoring_enabled) {
+        const result = await this.patchTelemetryConfig(
+          vin,
+          userId,
+          {},
+          ['SentryMode']
+        );
+
+        if (result?.success) {
+          await this.updateVehicleTelemetryStatus(userId, vin, false);
+          return {
+            success: true,
+            message: SUCCESS_MESSAGES.CONFIG_DELETED_SUCCESSFULLY,
+          };
+        }
+      }
+
       const accessToken = await this.getAccessToken(userId);
 
       await this.teslaApi.delete(


### PR DESCRIPTION
## Problem
When both Sentry Mode monitoring and Break-in monitoring are disabled, enabling Break-in monitoring would incorrectly enable Sentry Mode monitoring in the UI/database. This occurred because `syncVehiclesToDatabase` checked if *any* telemetry configuration existed on the vehicle (`telemetryConfig?.config !== null`). 

Additionally, disabling Sentry Mode deleted the entire telemetry config, which unintentionally disabled Break-in monitoring if it was active. Conversely, disabling Break-in monitoring did not remove the `ChargePortLatch` telemetry field from the config.

## Solution
1. **Precise Status Synchronization**: Modified `syncVehiclesToDatabase` to check specific fields: `SentryMode` for sentry mode monitoring, and `CenterDisplay` for break-in monitoring.
2. **Feature Clean-up**: Modified the break-in monitoring toggle to clean up both `CenterDisplay` and `ChargePortLatch` on disable.
3. **Graceful Deactivation**: Modified Sentry Mode disablement so that if break-in monitoring is active, it patches the telemetry config to remove only `SentryMode` rather than calling the API to delete the entire configuration.
4. **Tests**: Updated unit test mocks and expectations to match the new behavior, and added a unit test verifying Sentry Mode delete behavior when break-in is active.

## How to Test

### Automated Tests
Run the unit tests for both telemetry-config and break-in-monitoring-config:
```bash
yarn nx test api -- telemetry-config
yarn nx test api -- break-in-monitoring
```

### Manual Verification
1. Ensure both Sentry Mode monitoring and Break-in monitoring are disabled on the vehicle.
2. Enable ONLY **Break-in Monitoring**.
3. Verify that Sentry Mode monitoring remains **Disabled** in the UI/database.
4. Enable **Sentry Mode Monitoring** (both features should now be enabled).
5. Disable **Sentry Mode Monitoring**.
6. Verify that Sentry Mode monitoring is **Disabled** while Break-in monitoring remains **Enabled**.
