### PR TITLE
feat: pin vehicle-command-proxy to personal fork and fix api tests

### DIFF
--- a/apps/api/src/app/offensive-response/alerts-offensive-response.service.spec.ts
+++ b/apps/api/src/app/offensive-response/alerts-offensive-response.service.spec.ts
@@ -100,7 +100,7 @@ describe('The AlertsOffensiveResponseService class', () => {
       it('should trigger remote boombox only', async () => {
         await service.handleBreakInOffensiveResponse('5YJ3E1EA123456789', ['user-1']);
 
-        expect(mockTeslaVehicleCommandService.remoteBoombox).toHaveBeenCalledWith('5YJ3E1EA123456789', 'user-1', 0);
+        expect(mockTeslaVehicleCommandService.remoteBoombox).toHaveBeenCalledWith('5YJ3E1EA123456789', 'user-1', 1);
       });
     });
 

--- a/apps/api/src/app/offensive-response/alerts-offensive-response.service.ts
+++ b/apps/api/src/app/offensive-response/alerts-offensive-response.service.ts
@@ -13,7 +13,7 @@ export class AlertsOffensiveResponseService {
     @InjectRepository(Vehicle)
     private readonly vehicleRepository: Repository<Vehicle>,
     private readonly teslaVehicleCommandService: TeslaVehicleCommandService,
-  ) { }
+  ) {}
 
   async handleBreakInOffensiveResponse(vin: string, userIds: string[]): Promise<void> {
     for (const userId of userIds) {
@@ -43,7 +43,7 @@ export class AlertsOffensiveResponseService {
       if (break_in_offensive_response === OffensiveResponse.HONK) {
         result = await this.teslaVehicleCommandService.honkHorn(vin, userId);
       } else if (break_in_offensive_response === OffensiveResponse.FART) {
-        result = await this.teslaVehicleCommandService.remoteBoombox(vin, userId, 0);
+        result = await this.teslaVehicleCommandService.remoteBoombox(vin, userId, 1);
       } else {
         return false;
       }

--- a/apps/api/src/app/telemetry/services/tesla-vehicle-command.service.spec.ts
+++ b/apps/api/src/app/telemetry/services/tesla-vehicle-command.service.spec.ts
@@ -77,13 +77,13 @@ describe('The TeslaVehicleCommandService class', () => {
       });
 
       it('should attempt to send remote_boombox command with payload', async () => {
-        const result = await service.remoteBoombox('TESTVIN1234567890', 'user-1', 0);
+        const result = await service.remoteBoombox('TESTVIN1234567890', 'user-1', 1);
 
         expect(mockAccessTokenService.getAccessTokenForUserId).toHaveBeenCalledWith('user-1');
         expect(result.success).toBe(true);
         expect((service as any).teslaApi.post).toHaveBeenCalledWith(
           '/api/1/vehicles/TESTVIN1234567890/command/remote_boombox',
-          { sound: 0 },
+          { sound: 1 },
           expect.any(Object),
         );
       });

--- a/vehicle-command-proxy/Dockerfile
+++ b/vehicle-command-proxy/Dockerfile
@@ -1,5 +1,10 @@
 ARG TARGETPLATFORM
-FROM --platform=$TARGETPLATFORM tesla/vehicle-command:0.4.0 AS vehicle-command-binary
+FROM --platform=$BUILDPLATFORM golang:1.23-alpine AS vehicle-command-binary
+RUN apk add --no-cache git
+WORKDIR /go/src/github.com/teslamotors/vehicle-command
+RUN git clone https://github.com/abarghoud/vehicle-command-with-boombox.git . && git checkout a6468e67f7421b050a8e55cd2c771e4eb081ec06
+ARG TARGETOS TARGETARCH
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -ldflags="-s -w" -o /usr/local/bin/tesla-http-proxy ./cmd/tesla-http-proxy
 
 FROM --platform=$TARGETPLATFORM ubuntu:22.04
 
@@ -8,11 +13,11 @@ LABEL description="Tesla Vehicle Command service without volumes"
 LABEL version="1.0.0"
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates && \
-    rm -rf /var/lib/apt/lists/*
+  apt-get install -y --no-install-recommends ca-certificates && \
+  rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1001 vehicleuser && \
-    useradd -u 1001 -g vehicleuser -s /usr/sbin/nologin -d /home/vehicleuser vehicleuser
+  useradd -u 1001 -g vehicleuser -s /usr/sbin/nologin -d /home/vehicleuser vehicleuser
 
 RUN mkdir -p /config
 
@@ -27,6 +32,6 @@ RUN chown -R vehicleuser:vehicleuser /config /entrypoint.sh
 USER vehicleuser
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD pgrep tesla-http-proxy || exit 1
+  CMD pgrep tesla-http-proxy || exit 1
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/vehicle-command-proxy/build.sh
+++ b/vehicle-command-proxy/build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# Always run from the project root directory to ensure correct Docker context
+cd "$(dirname "$0")/.."
+
 IMAGE_NAME="abarghoud/sentryguard-vehicle-command"
 VERSION="${1:-latest}"
 PLATFORMS="linux/amd64,linux/arm64"
@@ -22,6 +25,7 @@ fi
 docker buildx build \
     --builder "${BUILDER_NAME}" \
     --platform "${PLATFORMS}" \
+    -f vehicle-command-proxy/Dockerfile \
     --tag "${IMAGE_NAME}:${VERSION}" \
     --push \
     .


### PR DESCRIPTION
## Description

This PR transitions the `vehicle-command-proxy` build to clone from your personal fork (`abarghoud/vehicle-command-with-boombox`) and pins it to a specific verified commit SHA.

### Why we are doing this:

**Official Repository Limitation**: The official `teslamotors/vehicle-command` repository does not implement the `remote_boombox` command (likely due to legal/liability limitations set by Tesla regarding noise/external speaker control), even though the Fleet API supports it.

https://github.com/teslamotors/vehicle-command/issues/266
https://github.com/Cromzinc/vehicle-command
