### PR TITLE
feat(mobile): add VinMask component to hide/reveal vehicle VIN

### DIFF
--- a/apps/mobile/src/core/ui/Icon.tsx
+++ b/apps/mobile/src/core/ui/Icon.tsx
@@ -41,6 +41,8 @@ const ioniconsFallback: Record<string, keyof typeof Ionicons.glyphMap> = {
   'paperplane.fill': 'paper-plane',
   'trash.fill': 'trash',
   'link': 'link',
+  'eye': 'eye-outline',
+  'eye.slash': 'eye-off-outline',
 };
 
 const useNativeSymbols = Platform.OS === 'ios';

--- a/apps/mobile/src/core/ui/VinMask.test.tsx
+++ b/apps/mobile/src/core/ui/VinMask.test.tsx
@@ -1,0 +1,44 @@
+jest.mock('react-native', () => ({
+  Platform: { select: (obj: any) => obj.ios || obj.default },
+  Pressable: 'Pressable',
+  StyleSheet: { create: (styles: any) => styles },
+  Text: 'Text',
+  View: 'View',
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('../theme', () => ({
+  useThemeColors: () => ({
+    secondaryLabel: 'secondaryLabelColor',
+  }),
+}));
+
+jest.mock('./AppText', () => ({
+  AppText: 'AppText',
+}));
+
+jest.mock('./Icon', () => ({
+  Icon: 'Icon',
+}));
+
+import { maskVin } from './VinMask';
+
+describe('The maskVin() function', () => {
+  const vin = '5YJ3E1EB8KF123456';
+  const expectedMaskedVin = '5YJ••••••••••••••';
+
+  describe('When adapting a standard 17-character VIN', () => {
+    it('should keep the first 3 characters and mask the rest with 14 bullets', () => {
+      expect(maskVin(vin)).toBe(expectedMaskedVin);
+    });
+  });
+
+  describe('When the VIN is too short', () => {
+    it('should return the original string untouched', () => {
+      expect(maskVin('5Y')).toBe('5Y');
+    });
+  });
+});

--- a/apps/mobile/src/core/ui/VinMask.tsx
+++ b/apps/mobile/src/core/ui/VinMask.tsx
@@ -1,0 +1,84 @@
+import type { JSX } from 'react';
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Platform, Pressable, StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
+
+import { TextVariant } from '../design/typography';
+import { useThemeColors } from '../theme';
+import { AppText } from './AppText';
+import { Icon } from './Icon';
+
+interface VinMaskProps {
+  vin: string;
+  color?: string;
+  style?: StyleProp<ViewStyle>;
+  variant?: TextVariant;
+}
+
+export function maskVin(vin: string): string {
+  return vin.length >= 3 ? `${vin.slice(0, 3)}••••••••••••••` : vin;
+}
+
+export function VinMask({
+  vin,
+  color,
+  style,
+  variant = TextVariant.Footnote,
+}: VinMaskProps): JSX.Element {
+  const { t } = useTranslation();
+  const colors = useThemeColors();
+  const [isVisible, setIsVisible] = useState(false);
+
+  const toggleVisibility = useCallback(() => {
+    setIsVisible((prev) => !prev);
+  }, []);
+
+  const maskedVin = maskVin(vin);
+
+  return (
+    <View style={[styles.container, style]}>
+      <AppText
+        variant={variant}
+        style={[
+          styles.vinText,
+          { color: color ?? colors.secondaryLabel },
+        ]}
+        numberOfLines={1}
+      >
+        {isVisible ? vin : maskedVin}
+      </AppText>
+      <Pressable
+        accessibilityLabel={isVisible ? t('vehicle.hideVin') : t('vehicle.showVin')}
+        accessibilityRole="button"
+        hitSlop={8}
+        onPress={toggleVisibility}
+        style={({ pressed }) => [
+          styles.button,
+          pressed && { opacity: 0.6 },
+        ]}
+      >
+        <Icon name={isVisible ? 'eye.slash' : 'eye'} size={14} color={colors.secondaryLabel} />
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 2,
+  },
+  container: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 6,
+  },
+  vinText: {
+    fontFamily: Platform.select({
+      ios: 'Courier',
+      android: 'monospace',
+      default: 'monospace',
+    }),
+  },
+});

--- a/apps/mobile/src/core/ui/index.ts
+++ b/apps/mobile/src/core/ui/index.ts
@@ -7,3 +7,4 @@ export { ListRow } from './ListRow';
 export { ListSection } from './ListSection';
 export { SegmentedControl, type SegmentOption } from './SegmentedControl';
 export { Surface } from './Surface';
+export { VinMask } from './VinMask';

--- a/apps/mobile/src/locales/en.json
+++ b/apps/mobile/src/locales/en.json
@@ -128,6 +128,8 @@
   "vehicle.offensiveFartEnabledDescription": "The fart command triggers when an intrusion attempt is detected.",
   "vehicle.openingTesla": "Opening Tesla...",
   "vehicle.openTesla": "Open Tesla",
+  "vehicle.showVin": "Show VIN",
+  "vehicle.hideVin": "Hide VIN",
   "vehicle.scopeCancelled": "Tesla authorization was cancelled or the token is missing.",
   "vehicle.scopeDescription": "Authorize SentryGuard to send a vehicle command before enabling the horn.",
   "vehicle.sentryDisabledDescription": "Enable the data collection required for Sentry alerts.",

--- a/apps/mobile/src/locales/fr.json
+++ b/apps/mobile/src/locales/fr.json
@@ -128,6 +128,8 @@
   "vehicle.offensiveFartEnabledDescription": "La commande de pet (boombox) se déclenche en cas de tentative d’intrusion détectée.",
   "vehicle.openingTesla": "Ouverture Tesla...",
   "vehicle.openTesla": "Ouvrir Tesla",
+  "vehicle.showVin": "Afficher le VIN",
+  "vehicle.hideVin": "Masquer le VIN",
   "vehicle.scopeCancelled": "Autorisation Tesla annulée ou token absent.",
   "vehicle.scopeDescription": "Autorise SentryGuard à envoyer une commande au véhicule avant d’activer le klaxon.",
   "vehicle.sentryDisabledDescription": "Active la collecte nécessaire aux alertes Sentinelle.",

--- a/apps/mobile/src/screens/VehicleDetailScreen.tsx
+++ b/apps/mobile/src/screens/VehicleDetailScreen.tsx
@@ -8,7 +8,7 @@ WebBrowser.maybeCompleteAuthSession();
 import { screenPadding, spacing } from '../core/design/metrics';
 import { TextVariant } from '../core/design/typography';
 import { useThemeColors } from '../core/theme';
-import { AppSwitch, AppText, GlassButton, GlassButtonVariant, Icon, ListRow, ListSection, SegmentedControl, Surface } from '../core/ui';
+import { AppSwitch, AppText, GlassButton, GlassButtonVariant, Icon, ListRow, ListSection, SegmentedControl, Surface, VinMask } from '../core/ui';
 import {
   confirmTelemetryDeletion,
   openVirtualKey,
@@ -62,9 +62,7 @@ export function VehicleDetailScreen({ route, navigation }: VehicleDetailScreenPr
         </View>
         <View style={styles.statusText}>
           <AppText variant={TextVariant.Headline}>{isProtected ? t('common.protected') : t('common.toConfigure')}</AppText>
-          <AppText variant={TextVariant.Footnote} color={colors.secondaryLabel}>
-            {vehicle.vin}
-          </AppText>
+          <VinMask vin={vehicle.vin} />
         </View>
       </Surface>
 

--- a/apps/mobile/src/screens/dashboard/components/VehicleCard.tsx
+++ b/apps/mobile/src/screens/dashboard/components/VehicleCard.tsx
@@ -4,7 +4,7 @@ import { Pressable, StyleSheet, View } from 'react-native';
 import { spacing } from '../../../core/design/metrics';
 import { TextVariant } from '../../../core/design/typography';
 import { useThemeColors } from '../../../core/theme';
-import { AppText, Icon, Surface } from '../../../core/ui';
+import { AppText, Icon, Surface, VinMask } from '../../../core/ui';
 import { Vehicle } from '../../../features/vehicles/domain/entities';
 import { TranslationFunction, isVehicleProtected } from '../dashboard.helpers';
 
@@ -29,9 +29,7 @@ export function VehicleCard({
           <View style={styles.header}>
             <View style={styles.titleBlock}>
               <AppText variant={TextVariant.Headline}>{vehicle.display_name ?? vehicle.model ?? t('common.vehicleFallback')}</AppText>
-              <AppText variant={TextVariant.Footnote} color={colors.secondaryLabel}>
-                {vehicle.vin}
-              </AppText>
+              <VinMask vin={vehicle.vin} />
             </View>
             <View style={[styles.badge, { backgroundColor: badgeSurface }]}>
               <AppText variant={TextVariant.Caption1} color={badgeLabel} style={styles.badgeText}>


### PR DESCRIPTION
Closes #137 

This PR introduces the VinMask component in the mobile app, aligning it with the web application's design to mask the vehicle VIN on the Dashboard and Vehicle Detail screens.

<img width="1179" height="639" alt="IMG_8445" src="https://github.com/user-attachments/assets/58894efb-0bbc-4b5a-8bdb-79e7cf0b20fd" />
