### PR TITLE
feat(mobile): add preview-apk EAS build profile for APK output

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -21,6 +21,13 @@
         "distribution": "store"
       }
     },
+    "preview-apk": {
+      "extends": "preview",
+      "android": {
+        "distribution": "internal",
+        "buildType": "apk"
+      }
+    },
     "production": {
       "corepack": true,
       "autoIncrement": true,

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -68,6 +68,8 @@
     "android": "expo run:android",
     "eas:build:preview": "sh -c 'set -a && . ./.env.local && set +a && NODE_ENV=production npx eas-cli build -p android --profile preview'",
     "eas:build:preview:local": "sh -c 'set -a && . ./.env.local && set +a && NODE_ENV=production npx eas-cli build -p android --profile preview --local'",
+    "eas:build:preview:apk": "sh -c 'set -a && . ./.env.local && set +a && NODE_ENV=production npx eas-cli build -p android --profile preview-apk'",
+    "eas:build:preview:apk:local": "sh -c 'set -a && . ./.env.local && set +a && NODE_ENV=production npx eas-cli build -p android --profile preview-apk --local'",
     "ios": "expo run:ios"
   },
   "expo": {


### PR DESCRIPTION
## Context

The `preview` profile produces an `.aab` (Android App Bundle), required for Play Store submission via `eas submit` (internal track). For testing and direct device installs we need an installable `.apk`.

## Changes

- **eas.json**: new `preview-apk` profile that `extends` `preview` and overrides `android.buildType` to `apk`. `preview` stays on `app-bundle`.
- **package.json**: two new scripts
  - `eas:build:preview:apk` — cloud build
  - `eas:build:preview:apk:local` — local build

## Usage

```bash
yarn eas:build:preview:apk:local
```