### PR TITLE
docs: refresh CLAUDE.md and AGENTS.md for the full monorepo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ If the user wants help with fixing an error in their CI pipeline, use the follow
 
 # SentryGuard
 
-Nx monorepo — Tesla vehicle monitoring with Telegram alerts.
+Nx monorepo — Tesla vehicle monitoring with Telegram + mobile-push alerts and an active break-in offensive response.
 
 ## Apps & Libs
 
@@ -30,7 +30,11 @@ Nx monorepo — Tesla vehicle monitoring with Telegram alerts.
 |---------|-----------|------|-------------|
 | `apps/api` | NestJS + TypeORM + PostgreSQL | 3001 | Jest (node env) |
 | `apps/webapp` | Next.js 16 (App Router, SSR) | 3000 | Jest (jsdom env) |
-| `libs/beta/domain` | Shared domain lib | — | Jest |
+| `apps/mobile` | Expo SDK 54 / React Native (iOS, Android, Expo Web) | 8081 / 3002 | Jest (node env) |
+| `libs/beta/domain` | `@sentryguard/beta-domain` — Tesla scopes + error codes | — | Jest |
+| `libs/telegram/domain` | `@sentryguard/telegram-domain` — Telegram-linking use-cases (web + mobile) | — | Jest |
+
+Infra images: `fleet-telemetry/` (Tesla telemetry TLS ingest → Kafka) and `vehicle-command-proxy/` (signs Tesla commands). Lib resolution uses Yarn workspaces + TS `customConditions` (no `paths` in `tsconfig.base.json`).
 
 ## Commands
 
@@ -40,25 +44,33 @@ All tasks via `nx`. Use `yarn` (Berry v4) — **not** npm.
 # Dev
 npx nx serve api          # NestJS with hot-reload (depends on build)
 npx nx dev webapp         # Next.js dev server
+npx nx start mobile       # Expo Metro (:8081); also run-ios / run-android / serve (web :3002)
 
 # Build
 npx nx build api          # Webpack (not Nest CLI)
 npx nx build webapp
+npx nx export mobile      # Metro JS bundle (CI bundle check)
 
 # Lint / Typecheck / Test
 npx nx lint api
 npx nx lint webapp
 npx nx typecheck api
+npx nx typecheck mobile   # uses tsconfig.app.json (plain tsconfig.json checks nothing)
 npx nx run-many -t lint   # all projects
 npx nx test api
 npx nx test webapp --watch
 npx nx test api --coverage
+npx jest <file> -c apps/<app>/jest.config.js   # single test file
 
-# CI order: lint → test → build
+# CI order: lint → typecheck(mobile) → test → build → export(mobile)
 yarn nx run-many -t lint
+yarn nx typecheck mobile
 yarn nx run-many -t test --skip-nx-cache
-yarn nx run-many -t build
+yarn nx run-many -t build --projects=!mobile
+yarn nx run-many -t export
 ```
+
+Mobile EAS builds (from `apps/mobile`): `yarn eas:build:preview` / `:preview:apk` (EAS cloud) and the `:local` variants (`yarn eas:build:preview:local`, `yarn eas:build:preview:apk:local`) build on-machine with no EAS credits. Profiles in `apps/mobile/eas.json`.
 
 ## Database Migrations
 
@@ -80,33 +92,39 @@ npm run kafka:send    # interactive test message sender
 npm run kafka:stop
 ```
 
-Kafka must be running before `npx nx serve api` for telemetry features to work. Default topic: `FleetTelemetry_V`.
+Kafka must be running before `npx nx serve api` for telemetry features to work. Topic via `KAFKA_TOPIC`: code/local-dev default is `TeslaLogger_V`; self-host/fleet-telemetry use `FleetTelemetry_V` — match it to the producer.
 
 ## Environment Setup
 
 - Copy `apps/api/.env.example` → `apps/api/.env`
 - Requires PostgreSQL running (see `DATABASE_*` vars)
 - Key secrets: `ENCRYPTION_KEY` (min 32 chars), `JWT_SECRET`, `TESLA_CLIENT_*`, `TELEGRAM_BOT_TOKEN`
+- Webapp: `NEXT_PUBLIC_API_URL` etc. served at **runtime** via `/api/runtime-config`. Mobile: `EXPO_PUBLIC_API_URL` in `apps/mobile/.env.local`. Self-host: `.env.selfhost.example`
 
 ## API Source Structure
 
 ```
 apps/api/src/
 ├── app/                    # NestJS modules
-│   ├── auth/               # Tesla OAuth
-│   ├── telemetry/          # Vehicle telemetry processing
+│   ├── auth/               # Tesla OAuth, JWT sessions, token encryption + refresh cron
+│   ├── telemetry/          # Vehicle telemetry processing (+ telemetry-cleanup)
 │   ├── telegram/           # Telegram bot integration
-│   ├── messaging/kafka/    # Kafka consumer (KafkaService)
-│   ├── alerts/             # Alert handlers & break-in offensive response
-│   ├── offensive-response/ # Offensive response API endpoints & config
-│   ├── onboarding/         # User onboarding
+│   ├── messaging/kafka/    # Kafka consumer (KafkaService; providers wired in app.module.ts)
+│   ├── alerts/             # Alert handlers (sentry / break-in / common fan-out)
+│   ├── offensive-response/ # Break-in honk/boombox config & execution
+│   ├── notifications/      # Expo mobile push + notification preferences
+│   ├── onboarding/         # User onboarding + announcements
 │   ├── waitlist/           # Waitlist management
 │   ├── consent/            # User consent
-│   ├── user/               # User management
-│   └── shared/             # Shared module
-├── entities/               # TypeORM entities (user, vehicle, telegram-config, user-consent, waitlist)
-├── config/                 # Centralized configs (throttle, database, pino, oci-logging)
-├── common/                 # Exceptions, guards, interceptors, services, utils
+│   ├── user/               # User management (+ language)
+│   ├── redirect/           # Tesla deep-link bounce page
+│   ├── tesla-public-key/   # Serves Tesla Fleet public key
+│   └── shared/             # RetryManager
+├── entities/               # 11 TypeORM entities (user, vehicle, telegram-config, user-consent,
+│                           #   user-session, push-device-token, notification-preferences,
+│                           #   alert-event, feature-announcement, user-dismissed-announcement, waitlist)
+├── config/                 # Centralized configs (throttle, database, pino, oci-logging, cron, lock-keys)
+├── common/                 # Exceptions, guards, interceptors, services (distributed-lock), utils (crypto)
 └── migrations/
 ```
 
@@ -114,17 +132,35 @@ apps/api/src/
 
 ```
 apps/webapp/src/
-├── app/           # Next.js App Router pages (dashboard, callback)
+├── app/           # App Router: public [locale]/ pages (SSR) + flat client flow (callback, consent, onboarding, dashboard)
+├── features/      # Clean architecture per domain: domain / data / presentation / di.ts
+├── core/          # api client (runtime URL via /api/runtime-config), i18n, query provider
 ├── components/    # React components (Tailwind CSS)
-└── lib/           # Utilities & hooks (useAuth, i18n)
+├── locales/       # en/fr common.json
+└── proxy.ts       # locale redirect middleware
 ```
+
+## Mobile Source Structure
+
+```
+apps/mobile/src/
+├── core/          # App.tsx, MobileShell, navigation, api client, theme, design system, i18n
+├── features/      # Same clean-architecture layout as webapp (domain/data/presentation/di.ts)
+└── screens/       # Presentational screens; logic in use-*.ts hooks
+```
+Not Expo Router — uses `@react-navigation` (bottom tabs: Dashboard / Alerts / Settings). Tesla OAuth via `expo-web-browser` + deep link `sentryguard://callback`; JWT in `expo-secure-store`. Push via `expo-notifications`. API URL = build-time `EXPO_PUBLIC_API_URL`.
 
 ## Key Architecture Patterns
 
+- **Telemetry flow**: fleet-telemetry server → Kafka (**JSON**, not protobuf at the API) → `TelemetryMessageHandlerService` (class-validator) → sentry/break-in handlers → `VehicleAlertNotifierService` fan-out.
+- **Dual-channel notifications**: Telegram (`TelegramService`, mute enforced) **and** Expo mobile push (`NotificationsService` → exp.host). Devices via `NotificationsController`.
+- **Offensive response**: on a confirmed break-in, `AlertsOffensiveResponseService` → `TeslaVehicleCommandService` sends `honk_horn`/`remote_boombox` through the vehicle-command proxy (`TESLA_API_BASE_URL`), gated on the `vehicle_cmds` scope.
 - **Rate limiting**: All throttle values centralized in `apps/api/src/config/throttle.config.ts`. Use named `ThrottleOptions` methods — never hardcode numbers.
-- **Token storage**: Tesla OAuth tokens stored **encrypted** via `TokenEncryptionService` (`apps/api/src/app/auth/services/token-encryption.service.ts`).
+- **Token storage**: Tesla OAuth tokens stored **encrypted** in `apps/api/src/common/utils/crypto.util.ts` (AES-256-CBC). *(There is no `token-encryption.service.ts`.)*
+- **Auth sessions**: server-side JWT sessions (`UserSessionService`, SHA-256 hash, max 5/user); token refresh on a cron with a Postgres advisory `DistributedLockService`.
+- **Clean architecture (frontends)**: web + mobile both use `features/<domain>/{domain,data,presentation,di.ts}` + TanStack Query + a hand-rolled `ApiClient`. `@sentryguard/telegram-domain` is shared between them.
 - **Cloudflare**: `CloudflareThrottlerGuard` extracts real IPs from `CF-Connecting-IP` header.
-- **i18n**: Both apps use i18next. Extract strings with `npx nx extract-i18n api` / `npx nx extract-i18n webapp`.
+- **i18n**: web + API use i18next, mobile uses react-i18next. Extract with `npx nx extract-i18n api` / `npx nx extract-i18n webapp`.
 
 ## Test Patterns
 
@@ -159,3 +195,11 @@ apps/webapp/src/
 ## Commit Convention
 
 Conventional Commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
+
+## Gotchas
+
+- Kafka topic differs: local-dev `TeslaLogger_V` vs self-host `FleetTelemetry_V` — set via `KAFKA_TOPIC`.
+- Mobile typecheck targets `tsconfig.app.json`; only mobile is typecheck-gated in CI.
+- Vehicle-command host default (`tesla-vehicle-command:8443`) differs from the compose service name (`vehicle-command`); `TESLA_API_BASE_URL` is set explicitly in self-host.
+- Vitest is installed but unused — everything runs Jest.
+- Self-host via `docker-compose.selfhost.yml` (see SELF_HOSTING.md); `docker-compose.yml` is local Kafka only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,28 @@ SentryGuard is a real-time Tesla vehicle monitoring and security alert system bu
 **Architecture**:
 - NestJS backend API (TypeORM + PostgreSQL + Kafka)
 - Next.js 16 frontend with App Router (SSR for SEO)
+- Expo / React Native mobile app (iOS, Android, Expo Web)
 - Tesla Fleet API integration for vehicle telemetry
-- Telegram Bot API for instant notifications
+- Telegram Bot API **and mobile push (Expo)** for instant notifications
+- Active **offensive response** (honk / boombox) on confirmed break-ins
 - Apache Kafka for real-time message processing
+- Two shared domain libs + two custom Docker infra images (fleet-telemetry, vehicle-command proxy)
+
+> A condensed version of this file lives in [AGENTS.md](AGENTS.md) (loaded by some tools). Keep the two in sync when commands or architecture change.
+
+### Monorepo Layout
+
+| Path | What it is | Stack | Test env |
+|------|-----------|-------|----------|
+| `apps/api` | Backend API + Kafka consumer | NestJS 11 + TypeORM + PostgreSQL | Jest (node) |
+| `apps/webapp` | Marketing site + dashboard | Next.js 16 App Router (SSR) | Jest (jsdom) |
+| `apps/mobile` | iOS / Android / Expo Web client | Expo SDK 54 + React Native 0.81 + React Navigation | Jest (node) |
+| `libs/beta/domain` | `@sentryguard/beta-domain` — Tesla scopes + error-code enums | Pure TS | Jest |
+| `libs/telegram/domain` | `@sentryguard/telegram-domain` — Telegram-linking use-cases shared by web + mobile | Pure TS | Jest |
+| `fleet-telemetry/` | Dockerized Tesla Fleet Telemetry server (TLS ingest → Kafka) | Go + Docker | — |
+| `vehicle-command-proxy/` | Dockerized Tesla vehicle-command HTTP proxy (signs commands) | Go + Docker | — |
+
+> **Workspace package resolution is non-obvious**: `tsconfig.base.json` has **no `paths`**. Libs resolve as Nx workspace packages via Yarn workspaces + the TS `customConditions: ["@tesla-guard/source"]` setting, so each lib's `package.json` `exports` points at its `./src/index.ts` (live source, no build step). Note the scope split: root/condition uses `@tesla-guard/*`, published libs use `@sentryguard/*`.
 
 ## Common Commands
 
@@ -23,9 +42,16 @@ npx nx serve api
 # Start WebApp (development mode)
 npx nx dev webapp
 
+# Start Mobile (Expo Metro bundler :8081)
+npx nx start mobile
+npx nx serve mobile        # Expo Web (:3002)
+npx nx run-ios mobile      # build & launch iOS simulator
+npx nx run-android mobile  # build & launch Android emulator
+
 # Build for production
 npx nx build api
 npx nx build webapp
+npx nx export mobile       # Metro JS bundle (CI "does it bundle" check)
 ```
 
 ### Testing
@@ -33,12 +59,17 @@ npx nx build webapp
 # Run all tests for a project
 npx nx test api
 npx nx test webapp
+npx nx test mobile
 
 # Run tests in watch mode
 npx nx test api --watch
 
 # Run tests with coverage
 npx nx test api --coverage
+
+# Run a SINGLE test file
+npx jest <path/to/file.test.ts> -c apps/<app>/jest.config.js
+# e.g. npx jest src/components/VinMask.test.tsx -c apps/webapp/jest.config.js
 ```
 
 ### Linting & Code Quality
@@ -46,9 +77,14 @@ npx nx test api --coverage
 # Lint specific project
 npx nx lint api
 npx nx lint webapp
+npx nx lint mobile
 
-# Type checking (via Nx plugin)
+# Lint everything
+npx nx run-many -t lint
+
+# Type checking (mobile uses tsconfig.app.json — see Known Gotchas)
 npx nx typecheck api
+npx nx typecheck mobile
 ```
 
 ### Kafka Development
@@ -72,6 +108,34 @@ npx nx extract-i18n api
 npx nx extract-i18n webapp
 ```
 
+### Database Migrations (run from `apps/api`)
+```bash
+cd apps/api
+npm run migration:generate -- <Name>   # diff entities → new file in src/migrations/
+npm run migration:run                   # apply pending
+npm run migration:revert                # roll back last
+npm run migration:show                  # list applied/pending
+```
+Migrations use `tsconfig.typeorm.json` and the DataSource in `apps/api/src/config/database.config.ts` (runs `src/migrations/*.ts` via the CLI, `dist/migrations/*.js` at runtime).
+
+### Mobile EAS Builds (run from `apps/mobile`)
+```bash
+yarn eas:build:preview            # signed Android app-bundle, profile "preview" (EAS cloud)
+yarn eas:build:preview:local      # same, built locally (--local, no EAS credits)
+yarn eas:build:preview:apk        # APK output, profile "preview-apk" (EAS cloud)
+yarn eas:build:preview:apk:local  # same APK, built locally (--local)
+```
+These `source ./.env.local` then call `eas-cli`. The `:local` variants build on your machine (no EAS Build credits). Profiles live in `apps/mobile/eas.json`.
+
+### CI Order (mirror locally before pushing)
+```bash
+yarn nx run-many -t lint
+yarn nx typecheck mobile                    # only mobile is typecheck-gated today
+yarn nx run-many -t test --skip-nx-cache
+yarn nx run-many -t build --projects=!mobile
+yarn nx run-many -t export                  # mobile bundle check
+```
+
 ## Critical Architecture Patterns
 
 ### Rate Limiting Architecture
@@ -87,68 +151,126 @@ import { ThrottleOptions } from '../../config/throttle.config';
 @Throttle(ThrottleOptions.critical())           // For resource-intensive operations
 ```
 
-The system uses `CloudflareThrottlerGuard` which extracts real client IPs from Cloudflare headers (`CF-Connecting-IP`).
+The system uses `CloudflareThrottlerGuard` (`apps/api/src/common/guards/`), registered globally, which resolves the real client IP with precedence `CF-Connecting-IP → X-Forwarded-For[0] → X-Real-IP → req.ip` (`main.ts` sets `trust proxy`). Presets (all 60s TTL): `authenticatedRead` 200, `authenticatedWrite` 100, `critical` 50, `publicSensitive` 40, `default` 100.
 
 ### Telemetry Message Flow
-1. **Tesla Vehicle** → sends telemetry data via Fleet API
-2. **Kafka** → receives protobuf messages on topic `FleetTelemetry_V`
-3. **KafkaService** (`apps/api/src/app/messaging/kafka/kafka.service.ts`) → consumes messages
-4. **TelemetryMessageHandlerService** → handles and validates messages
-5. **SentryAlertHandlerService** → processes Sentry Mode events
-6. **TelegramService** → sends alerts to users via Telegram Bot API
+1. **Tesla Vehicle** → streams telemetry to the **`fleet-telemetry/`** server (TLS :8443), which decodes Tesla's protobuf and publishes **JSON** to Kafka
+2. **Kafka** → topic from `KAFKA_TOPIC` (code/local-dev default `TeslaLogger_V`; self-host/fleet-telemetry use `FleetTelemetry_V` — see Known Gotchas)
+3. **KafkaService** (`apps/api/src/app/messaging/kafka/kafka.service.ts`) → consumes batches (concurrency-limited); providers are wired in `app.module.ts`, not a dedicated module
+4. **TelemetryMessageHandlerService** (`apps/api/src/app/telemetry/handlers/`) → `JSON.parse`s the payload and validates with **class-validator** via `TelemetryValidationService`, then fans out with `Promise.allSettled`
+5. **SentryAlertHandlerService** / **BreakInAlertHandlerService** (`apps/api/src/app/alerts/`) → interpret events (break-in defers ~3s and suppresses charge-port false positives via `ChargePortLatchTrackerService`)
+6. **VehicleAlertNotifierService** (`apps/api/src/app/alerts/common/`) → central fan-out: persists `AlertEvent`s, notifies each user over **Telegram + mobile push**, and triggers the offensive response
+
+> ⚠️ The payload is **JSON at the API layer, not Protobuf** — protobuf decoding happens upstream in the fleet-telemetry server. (`@types/google-protobuf` is a leftover dependency.)
 
 **Retry Mechanism**:
-- Kafka connection retries configured via `KAFKA_MAX_RETRIES`, `KAFKA_RETRY_DELAY`, `KAFKA_MAX_RETRY_DELAY`
-- Message processing retries via `RetryManager` class with exponential backoff
+- Kafka **connection** retries: `KafkaService.connectWithRetry` via `KAFKA_MAX_RETRIES`, `KAFKA_RETRY_DELAY`, `KAFKA_MAX_RETRY_DELAY`
+- **Message processing** retries: `RetryManager` (`apps/api/src/app/shared/retry-manager.service.ts`) with exponential backoff (`KAFKA_MESSAGE_*`); also reused by Telegram for retryable sends
 - Failed messages after max retries are logged for investigation
 
+### Notification Channels (Telegram + Mobile Push)
+Notifications are **dual-channel**, fanned out in `VehicleAlertNotifierService.notifyUser()`:
+- **Telegram** — `TelegramService` (Telegraf). Mute is enforced here via `TelegramMuteService.checkIsNotificationMuted`.
+- **Mobile push** — `NotificationsService.sendPushAlert()` → Expo push API (`https://exp.host/--/api/v2/push/send`). Stale tokens (`DeviceNotRegistered`) are deleted automatically; Android routes critical vs normal via channels `sentryguard-critical-alerts-v5` / `sentryguard-alerts`.
+
+Devices register through `NotificationsController` (`POST/DELETE /notifications/push-token`, `GET/POST /notifications/preferences`). Entities: `PushDeviceToken` (per-device flags), `NotificationPreferences` (global `telegram_enabled`).
+
+### Offensive Response (break-in counter-measures)
+- Enum `OffensiveResponse { DISABLED, HONK, FART }` (`apps/api/src/app/alerts/enums/offensive-response.enum.ts`), stored per-vehicle in `Vehicle.break_in_offensive_response`.
+- Configured via `PATCH /offensive-response/:vin` (requires Tesla `vehicle_cmds` scope) or a Telegram button.
+- On a confirmed break-in within a latency threshold, `AlertsOffensiveResponseService` → `TeslaVehicleCommandService` (`apps/api/src/app/telemetry/services/tesla-vehicle-command.service.ts`) POSTs `honk_horn` / `remote_boombox` to `TESLA_API_BASE_URL` (the **vehicle-command proxy**) using the user's decrypted access token.
+
 ### Authentication & Token Management
-- **OAuth 2.0 flow** with Tesla for user authentication
-- **JWT tokens** for API authentication (managed by Passport.js)
+- **OAuth 2.0 flow** with Tesla for user authentication (scopes `openid vehicle_device_data vehicle_cmds offline_access user_data`; CSRF via a signed `state` JWT)
+- **JWT tokens** for API authentication (managed by Passport.js), but **sessions are tracked server-side**: `UserSessionService` stores a SHA-256 hash of each JWT (`UserSession` entity), enforces **max 5 sessions/user**, and supports revocation
 - **Tesla access tokens** are stored ENCRYPTED in the database (using `ENCRYPTION_KEY`)
-- Token encryption/decryption handled in `apps/api/src/app/auth/services/token-encryption.service.ts`
+- Token encryption/decryption is handled in **`apps/api/src/common/utils/crypto.util.ts`** (AES-256-CBC, key derived via `scryptSync`, random IV, `iv:cipher` hex) — *not* in an `auth/services/token-encryption.service.ts` (that file does not exist)
+- **Refresh on a cron**: `TeslaTokenRefreshSchedulerService` (`@Cron`, default 02:00 daily) → `TeslaTokenRefreshService` (row-locked)
+- **Distributed lock**: cron jobs are guarded by `DistributedLockService` (Postgres `pg_try_advisory_xact_lock`) so only one instance runs each job (keys in `config/scheduler-lock-key.config.ts`)
 
 ### Database Entity Relationships
+
+There are **11 entities** in `apps/api/src/entities/`, centered on `User`:
 ```
-User (1) ──< (N) Vehicle
-User (1) ──< (1) TelegramConfig
-User (1) ──< (1) UserConsent
+User (1) ──< (N) Vehicle, UserConsent, UserSession, PushDeviceToken, AlertEvent
+User (1) ──< (1) TelegramConfig, NotificationPreferences
+FeatureAnnouncement (N) >──< (N) User   (via UserDismissedAnnouncement)
+Waitlist (standalone)
 ```
 
-Key entities in `apps/api/src/entities/`:
+Key entities:
 - `user.entity.ts` - User profile + encrypted Tesla tokens
-- `vehicle.entity.ts` - Vehicle details + telemetry config
-- `telegram-config.entity.ts` - Telegram chat IDs + link tokens
+- `vehicle.entity.ts` - Vehicle details + telemetry config + `break_in_offensive_response`
+- `telegram-config.entity.ts` - Telegram chat IDs + link tokens + mute status
 - `user-consent.entity.ts` - User consent tracking
+- `user-session.entity.ts` - Hashed JWT sessions (max 5/user)
+- `push-device-token.entity.ts` - Expo push tokens + per-device flags
+- `notification-preferences.entity.ts` - Global `telegram_enabled` per user
+- `alert-event.entity.ts` - Persisted alert history (type/severity enums)
+- `feature-announcement.entity.ts` / `user-dismissed-announcement.entity.ts` - In-app announcements
+- `waitlist.entity.ts` - Pre-launch waitlist
 
 ### Frontend Architecture (Next.js App Router)
-- **Server-Side Rendering** for SEO optimization
-- All dashboard pages are in `apps/webapp/src/app/dashboard/`
-- Protected routes use `useAuth` hook (`apps/webapp/src/lib/useAuth.ts`)
-- i18n via `react-i18next` with language switcher component
+- **Server-Side Rendering** for SEO optimization. Two routing zones: public localized SSR pages under `src/app/[locale]/` (landing, faq, legal), and flat client pages for the auth/dashboard flow (`callback`, `consent`, `onboarding`, `dashboard/*`)
+- Locale redirect middleware is **`apps/webapp/src/proxy.ts`** (Next's `proxy` filename convention), keyed on a `locale` cookie / `accept-language`
+- Dashboard pages are in `apps/webapp/src/app/dashboard/`; client-side guards live in `dashboard/layout.tsx` (no auth → `/`, no consent → `/consent`, onboarding incomplete → `/onboarding`)
+- The auth hook is **`useAuthQuery`** in `apps/webapp/src/features/auth/` (there is **no** `src/lib/useAuth.ts`)
+- **API URL is resolved at runtime** via `/api/runtime-config` (a `force-dynamic` route reading `NEXT_PUBLIC_*` server env), so one Docker image is configured at deploy time. JWT is stored in `localStorage` (`jwt_token`)
+- State is **TanStack React Query v5** only (no Redux/Zustand). Error tracking is **Rollbar**
+- i18n via `react-i18next` (locales `en`/`fr` in `src/locales/<lng>/common.json`); SSR dictionary lookup in `src/core/i18n/server-i18n.tsx`
 - Tailwind CSS for styling (no CSS modules except `page.module.css`)
 
 ### Mobile Menu Pattern
 The dashboard layout uses a **hamburger menu** for mobile (see `apps/webapp/src/app/dashboard/layout.tsx`):
-- Hidden by default with `max-h-0 opacity-0`
+- Toggles between `max-h-0 opacity-0` (closed) and `max-h-screen opacity-100` (open)
 - Animated slide-down with `transition-all duration-300 ease-in-out`
 - Automatically closes when navigating (`setMobileMenuOpen(false)`)
 - Toggle button shows hamburger (☰) or close (×) icon
+
+### Clean Architecture on the Frontends (web + mobile share this)
+Both `apps/webapp` and `apps/mobile` organize feature code identically — read one and you understand the other:
+```
+features/<domain>/
+├── domain/          # entities, use-cases, *.requirements.ts interfaces
+├── data/            # *.api-repository.ts (real) + *.mock-repository.ts (demo/offline)
+├── presentation/    # React Query hooks (queries/), containers/views, screen hooks
+└── di.ts            # manual DI: instantiate repository → use-cases → create hook
+```
+- **Data layer**: a single hand-rolled `ApiClient` (`core/api/api-client.ts`) wraps `fetch`, attaches `Authorization: Bearer`, parses `ApiError`/`ScopeError`, and auto-refreshes once on `401` (`POST /auth/refresh-session`)
+- **State**: TanStack React Query v5 is the only server-state layer; query keys are per-feature; mutations invalidate their own key
+- **Demo mode**: a `'demo-token'` swaps real repositories for mock ones (`Dynamic*Repository` in each `di.ts`)
+- `libs/telegram/domain` (`@sentryguard/telegram-domain`) is the **shared** Telegram-linking contract consumed by both frontends
+
+### Mobile App Architecture (Expo / React Native)
+- **Not Expo Router.** Entry `index.js` → `src/core/App.tsx`. Nav tree: `MobileShell.tsx` (gates on session/consent/onboarding) → `MainScreen.tsx` (bottom tabs: Dashboard / Alerts / Settings)
+- Source layout mirrors the web Clean Architecture (`core/`, `features/<domain>/`, `screens/`); screens are presentational, logic lives in `use-*.ts` hooks
+- **Login**: backend Tesla OAuth opened via `expo-web-browser` (iOS) / `Linking` (Android); callback caught by deep link `sentryguard://callback`; token → **expo-secure-store** (`sentryguard.jwt`)
+- **API URL** is **build-time** `EXPO_PUBLIC_API_URL` (inlined by Metro) with an optional user override saved in SecureStore
+- **Push**: `expo-notifications`; token registered to `POST /notifications/push-token`, cleared on logout. Android critical alerts use a custom native module (`apps/mobile/modules/dnd-access/`, Kotlin) for Do-Not-Disturb bypass
+- **UI**: Apple-style design system in `core/design/` + "liquid glass" components (`expo-glass-effect` with `expo-blur` fallback); theming via `core/theme.tsx`. Config split: static `app.json` + dynamic `app.config.js`
 
 ## Environment Configuration
 
 ### API (.env)
 Critical environment variables:
 - **Database**: `DATABASE_HOST`, `DATABASE_PORT`, `DATABASE_USER`, `DATABASE_PASSWORD`, `DATABASE_NAME`
-- **Security**: `ENCRYPTION_KEY` (min 32 chars), `JWT_SECRET`
-- **Tesla**: `TESLA_CLIENT_ID`, `TESLA_CLIENT_SECRET`, `TESLA_FLEET_TELEMETRY_SERVER_HOSTNAME`
+- **Security**: `ENCRYPTION_KEY` (min 32 chars), `JWT_SECRET`, `JWT_OAUTH_STATE_SECRET`
+- **Tesla**: `TESLA_CLIENT_ID`, `TESLA_CLIENT_SECRET`, `TESLA_FLEET_TELEMETRY_SERVER_HOSTNAME`, `TESLA_API_BASE_URL` (vehicle-command proxy)
 - **Telegram**: `TELEGRAM_BOT_TOKEN`, `TELEGRAM_MODE`, `TELEGRAM_WEBHOOK_BASE`
-- **Kafka**: `KAFKA_BROKERS`, `KAFKA_TOPIC` (default: `FleetTelemetry_V`)
+- **Kafka**: `KAFKA_BROKERS`, `KAFKA_TOPIC` (code default `TeslaLogger_V`; self-host uses `FleetTelemetry_V`)
 - **Rate Limiting**: See `apps/api/.env.example` for all `THROTTLE_*` variables
 
 ### WebApp (.env)
-- WebApp typically gets API URL from build-time configuration
-- Check `apps/webapp/next.config.js` for environment-specific settings
+- API URL is read **at runtime** through `/api/runtime-config`, not inlined at build time
+- Vars: `NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_VIRTUAL_KEY_PAIRING_URL`, `NEXT_PUBLIC_ROLLBAR_CLIENT_TOKEN`, `ROLLBAR_SERVER_TOKEN`, `NEXT_PUBLIC_DISCORD_URL`
+- `next.config.js` uses `output: 'standalone'` (Docker) and disables ESLint during build
+
+### Mobile (.env.local)
+- `EXPO_PUBLIC_API_URL`, `EXPO_PUBLIC_VIRTUAL_KEY_PAIRING_URL`, optional `EXPO_PUBLIC_DEMO_*` (all inlined by Metro — never put real secrets here)
+
+### Self-Hosting
+- `docker-compose.selfhost.yml` + `.env.selfhost.example` (fail-fast `${VAR:?}` syntax). Full guide in [SELF_HOSTING.md](SELF_HOSTING.md)
+- `docker-compose.yml` is **local-dev Kafka only** (Zookeeper + Kafka + message simulator), no app containers
 
 ## Testing Practices
 
@@ -317,21 +439,38 @@ The project is designed to work behind Cloudflare:
 
 ## Kafka Message Schema
 
-Messages use **Protobuf** format (see `@types/google-protobuf`). Key fields:
+By the time messages reach the API consumer they are **JSON** (the fleet-telemetry server decodes Tesla's protobuf upstream). `TelemetryMessageHandlerService.parseMessage` does `JSON.parse`, then `TelemetryValidationService` validates with **class-validator**. Key fields:
 - `vin` - Vehicle Identification Number
-- `data` - Telemetry payload containing Sentry Mode status
-- Validation performed by `TelemetryValidationService`
+- `data` - Telemetry payload containing Sentry Mode / break-in state
+- The legacy `@types/google-protobuf` dependency is **not** used at this layer
 
 ## Nx Configuration
 
 This is an Nx monorepo. Key points:
-- Always run tasks through Nx: `npx nx <target> <project>`
+- Always run tasks through Nx: `npx nx <target> <project>` (and `nx run-many`, `nx affected`)
 - Use `nx affected` for CI optimization
-- Project configurations in `apps/*/project.json`
-- Use Nx MCP tools when available for workspace analysis
+- Project configurations in `apps/*/project.json` (the webapp uses inferred Next.js targets — no `project.json`)
+- Use Nx MCP tools when available for workspace analysis (`nx_workspace`, `nx_project_details`, `nx_docs`)
+- Module boundaries are enforced via `@nx/enforce-module-boundaries` in `eslint.config.mjs` (currently one permissive `*` constraint — no scope/type partitioning yet)
+- **Vitest tooling is installed but unused** — every project actually runs Jest (`@swc/jest`)
+
+## CI/CD (`.github/workflows/`)
+
+- **`ci.yml`** (push to `main` + PRs): lint → `typecheck mobile` → test (`--skip-nx-cache`) → build (all but mobile) → `export` mobile bundle
+- **`docker.yml`** (push to `main` + manual): multi-arch (amd64/arm64) build & push of `api`, `webapp`, `fleet-telemetry`, `vehicle-command` images to GHCR
+- **`mobile-build.yml`**: PR builds run `eas build --local` (no EAS credits) — Android `assembleDebug` + iOS simulator build, secret-free for fork PRs; manual signed builds submit to Play Internal Sharing / TestFlight when `EXPO_TOKEN` is present
+
+## Known Gotchas
+
+- **Mobile typecheck** must target `tsconfig.app.json` (`npx nx typecheck mobile` does this); the plain `tsconfig.json` checks nothing
+- **Kafka topic name is inconsistent**: API code default + local scripts use `TeslaLogger_V`, while fleet-telemetry + self-host default to `FleetTelemetry_V`. Always configurable via `KAFKA_TOPIC` — match it to the producer
+- **Vehicle-command host default** in code is `https://tesla-vehicle-command:8443`, but the compose service is named `vehicle-command` and sets `TESLA_API_BASE_URL` explicitly
+- Only **mobile** is currently typecheck-gated in CI; api/webapp typecheck is not yet enforced
 
 ## Additional Documentation
 
 - See [KAFKA-README.md](KAFKA-README.md) for Kafka setup
+- See [SELF_HOSTING.md](SELF_HOSTING.md) for the full Docker self-host guide
 - See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines
 - See [SECURITY.md](SECURITY.md) for security policies
+- See [apps/mobile/README.md](apps/mobile/README.md) for mobile-specific docs


### PR DESCRIPTION
## Summary

Refreshes both AI guide files (`CLAUDE.md` and `AGENTS.md`) to match the current `testing` branch. The previous versions predated the mobile app and contained several stale facts.

## What changed

- **New coverage**: `apps/mobile` (Expo / React Native), shared libs (`@sentryguard/beta-domain`, `@sentryguard/telegram-domain`), and the `fleet-telemetry` / `vehicle-command-proxy` Docker images.
- **Corrections**: telemetry is **JSON** (not Protobuf) at the API layer; token encryption is in `common/utils/crypto.util.ts`; the webapp resolves its API URL **at runtime** via `/api/runtime-config`; the auth hook is `features/auth/useAuthQuery` (there is no `lib/useAuth.ts`).
- **New architecture sections**: dual-channel notifications (Telegram + Expo push), offensive response (honk/boombox), server-side JWT sessions, token-refresh cron + distributed lock, and the shared Clean Architecture pattern.
- **New commands**: mobile dev/build/EAS (incl. `--local` variants), single-test, migrations, and CI order.
- **Known Gotchas** section (Kafka topic naming, mobile typecheck config, vehicle-command host, unused Vitest).

## Notes

- Docs-only — no code changes. Original sections (test examples, Security, Cloudflare, full Code Style) were preserved, not removed.
- `apps/mobile/app.json` (a pre-existing local edit) is intentionally excluded from this PR.