### PR TITLE
fix(mobile): keep vehicle detail back button reliable on iOS

### DIFF
--- a/apps/mobile/src/core/navigation.ts
+++ b/apps/mobile/src/core/navigation.ts
@@ -16,7 +16,7 @@ export type MainStackParamList = {
   Onboarding: undefined;
   Tabs: undefined;
   TelegramSettings: undefined;
-  VehicleDetail: { vehicleId: string };
+  VehicleDetail: { vehicleId: string; title?: string };
 };
 
 export type AppTabParamList = {

--- a/apps/mobile/src/core/shell/MainScreen.tsx
+++ b/apps/mobile/src/core/shell/MainScreen.tsx
@@ -45,7 +45,11 @@ export function MainScreen({ onLogout }: { onLogout(): Promise<void> }): JSX.Ele
       <MainStack.Screen name="Onboarding" options={{ headerShown: true, presentation: 'card', title: t('onboarding.resumeTitle') }}>
         {({ navigation }) => <OnboardingScreen onComplete={() => navigation.goBack()} />}
       </MainStack.Screen>
-      <MainStack.Screen name="VehicleDetail" component={VehicleDetailScreen} options={{ headerShown: true, presentation: 'card' }} />
+      <MainStack.Screen
+        name="VehicleDetail"
+        component={VehicleDetailScreen}
+        options={({ route }) => ({ headerShown: true, presentation: 'card', title: route.params.title ?? t('common.vehicleFallback') })}
+      />
       <MainStack.Screen name="TelegramSettings" component={TelegramSettingsScreen} options={{ headerShown: true, presentation: 'card' }} />
       <MainStack.Screen name="DeleteAccount" options={{ headerShown: true, presentation: 'card' }}>
         {() => <DeleteAccountScreen onLogout={onLogout} />}

--- a/apps/mobile/src/screens/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/DashboardScreen.tsx
@@ -69,7 +69,7 @@ export function DashboardScreen(): JSX.Element {
       renderItem={({ item }) => (
         <VehicleCard
           vehicle={item}
-          onSelect={() => navigation.navigate('VehicleDetail', { vehicleId: item.vin })}
+          onSelect={() => navigation.navigate('VehicleDetail', { vehicleId: item.vin, title: item.display_name ?? item.model })}
           t={t}
         />
       )}

--- a/apps/mobile/src/screens/VehicleDetailScreen.tsx
+++ b/apps/mobile/src/screens/VehicleDetailScreen.tsx
@@ -1,6 +1,5 @@
 import * as WebBrowser from 'expo-web-browser';
 import type { JSX } from 'react';
-import { useLayoutEffect } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
 
 WebBrowser.maybeCompleteAuthSession();
@@ -18,7 +17,7 @@ import { VehicleAction } from './vehicle-detail/vehicle-detail.types';
 import { useVehicleDetail } from './vehicle-detail/use-vehicle-detail';
 import type { VehicleDetailScreenProps } from '../core/navigation';
 
-export function VehicleDetailScreen({ route, navigation }: VehicleDetailScreenProps): JSX.Element {
+export function VehicleDetailScreen({ route }: VehicleDetailScreenProps): JSX.Element {
   const colors = useThemeColors();
   const {
     actionMutation,
@@ -30,11 +29,6 @@ export function VehicleDetailScreen({ route, navigation }: VehicleDetailScreenPr
     vehicle,
     vehicleCommandsAuthorized,
   } = useVehicleDetail(route.params.vehicleId);
-
-  const headerTitle = vehicle?.display_name ?? vehicle?.model ?? t('common.vehicleFallback');
-  useLayoutEffect(() => {
-    navigation.setOptions({ headerShown: true, title: headerTitle });
-  }, [navigation, headerTitle]);
 
   if (!vehicle) {
     return (


### PR DESCRIPTION
## Problem

On the vehicle detail screen, the native back arrow sometimes does nothing on iOS — the button is tapped but no navigation happens. It's intermittent (not on every iOS device/version). Reported on iPhone 15 Pro / iOS 27.0.

## Root cause

The navigation bar is native (`@react-navigation/native-stack` → react-native-screens). `VehicleDetailScreen` was the **only** screen reconfiguring its native header **after mount**: a `useLayoutEffect` called `setOptions({ headerShown: true, title })` once the vehicle data loaded (title went from a fallback to the real name).

When that update fires **during the push transition**, react-native-screens rebuilds the native header item, and the back button can lose its action → intermittently dead. The timing (cached/fast data landing mid-transition vs. after) explains why it only reproduces on some devices/versions, and why it's specific to this screen.

## Fix

Remove the dynamic header reconfiguration entirely. The vehicle name is already known when navigating (from the dashboard), so:

- Pass `title` as a navigation param (`DashboardScreen`).
- Set the title in the screen's **static** options (`MainScreen`), with a fallback.
- Remove the `useLayoutEffect` + `setOptions` from `VehicleDetailScreen`.

The native header (and its back button) is now configured **once at push** and never rebuilt, so the back action stays attached. The dashboard is the only entry point to this screen, so there's no edge case.

## Verification

- `nx typecheck mobile`
- `nx lint mobile` (no new warnings)
- Needs on-device confirmation on iOS (the bug is intermittent and can't be reproduced in CI).