### PR TITLE
fix(api): keep push disabled across app restarts

### DIFF
--- a/apps/api/src/app/notifications/notifications.service.spec.ts
+++ b/apps/api/src/app/notifications/notifications.service.spec.ts
@@ -97,4 +97,62 @@ describe('The NotificationsService class', () => {
       });
     });
   });
+
+  describe('The registerPushToken() method', () => {
+    const fakeToken = 'ExponentPushToken[fake]';
+
+    describe('When the device token is new', () => {
+      beforeEach(async () => {
+        mockPushDeviceTokenRepository.findOne.mockResolvedValue(null);
+        await service.registerPushToken(fakeUserId, fakeToken, 'android');
+      });
+
+      it('should create the device with push enabled', () => {
+        expect(mockPushDeviceTokenRepository.upsert).toHaveBeenCalledWith(
+          { userId: fakeUserId, token: fakeToken, platform: 'android', push_enabled: true },
+          { conflictPaths: ['token'], skipUpdateIfNoValuesChanged: true }
+        );
+      });
+    });
+
+    describe('When the device token is already registered with push disabled', () => {
+      let existingDevice: PushDeviceToken;
+
+      beforeEach(async () => {
+        existingDevice = { ...createDevice(), platform: 'android', push_enabled: false };
+        mockPushDeviceTokenRepository.findOne.mockResolvedValue(existingDevice);
+        await service.registerPushToken(fakeUserId, fakeToken, 'android');
+      });
+
+      it('should not re-enable push on the existing device', () => {
+        expect(mockPushDeviceTokenRepository.upsert).not.toHaveBeenCalled();
+      });
+
+      it('should not rewrite the unchanged device', () => {
+        expect(mockPushDeviceTokenRepository.save).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('When the registered device reports a new platform', () => {
+      let existingDevice: PushDeviceToken;
+
+      beforeEach(async () => {
+        existingDevice = { ...createDevice(), platform: 'ios', push_enabled: false };
+        mockPushDeviceTokenRepository.findOne.mockResolvedValue(existingDevice);
+        await service.registerPushToken(fakeUserId, fakeToken, 'android');
+      });
+
+      it('should save the device with the new platform', () => {
+        expect(mockPushDeviceTokenRepository.save).toHaveBeenCalledWith(
+          expect.objectContaining({ platform: 'android' })
+        );
+      });
+
+      it('should keep push disabled on the saved device', () => {
+        expect(mockPushDeviceTokenRepository.save).toHaveBeenCalledWith(
+          expect.objectContaining({ push_enabled: false })
+        );
+      });
+    });
+  });
 });

--- a/apps/api/src/app/notifications/notifications.service.ts
+++ b/apps/api/src/app/notifications/notifications.service.ts
@@ -56,11 +56,26 @@ export class NotificationsService {
   }
 
   public async registerPushToken(userId: string, token: string, platform?: string): Promise<{ success: boolean }> {
+    const existingDevice = await this.findPushDevice(userId, token);
+    if (existingDevice) {
+      await this.refreshPushDeviceMetadata(existingDevice, platform);
+      return { success: true };
+    }
+
     await this.pushDeviceTokenRepository.upsert(
       { userId, token, platform, push_enabled: true },
       { conflictPaths: ['token'], skipUpdateIfNoValuesChanged: true }
     );
     return { success: true };
+  }
+
+  private async refreshPushDeviceMetadata(device: PushDeviceToken, platform?: string): Promise<void> {
+    if (!platform || device.platform === platform) {
+      return;
+    }
+
+    device.platform = platform;
+    await this.pushDeviceTokenRepository.save(device);
   }
 
   public async removePushToken(userId: string, token: string): Promise<{ success: boolean }> {

--- a/apps/mobile/src/screens/onboarding/use-onboarding.ts
+++ b/apps/mobile/src/screens/onboarding/use-onboarding.ts
@@ -7,7 +7,7 @@ import { useTelegramStatusSync } from '../../core/hooks/useTelegramStatusSync';
 import { resolveDeviceLanguage } from '../../core/i18n';
 import { acceptConsentUseCase, getConsentStatusUseCase, getConsentTextUseCase } from '../../features/consent/di';
 import { completeOnboardingUseCase, getOnboardingStatusUseCase, skipOnboardingUseCase } from '../../features/onboarding/di';
-import { getNotificationPreferencesUseCase } from '../../features/notifications/di';
+import { getNotificationPreferencesUseCase, updateNotificationPreferencesUseCase } from '../../features/notifications/di';
 import { getTelegramStatusUseCase } from '../../features/telegram/di';
 import { getUserLanguageUseCase, updateUserLanguageUseCase } from '../../features/user/di';
 import { UserLanguage } from '../../features/user/domain/entities';
@@ -156,6 +156,7 @@ export function useOnboarding(onComplete: () => void) {
     try {
       const token = await registerDeviceForPush(setMessage, t);
       if (token) {
+        await updateNotificationPreferencesUseCase.execute({ push_enabled: true }, token);
         setPushToken(token);
         await queryClient.invalidateQueries({ queryKey: ['notification-preferences'] });
       }


### PR DESCRIPTION
## Problem

Turning push notifications off in the mobile app does not survive an app restart. On every app open, the mobile client silently re-registers its Expo push token (`usePushTokenSync`), and `NotificationsService.registerPushToken` upserts the device row with a hardcoded `push_enabled: true` — silently re-enabling push the user had just turned off. Toggling "critical only" could re-enable push through the same side effect.

## Fix

**API** (`notifications.service.ts`):
- `registerPushToken` no longer forces `push_enabled` on an existing device row: silent re-registration now only refreshes device metadata (`platform`, and only when it actually changed, to avoid a DB write on every app open).
- A brand-new device row is still created with `push_enabled: true`, so first-run behavior is unchanged.

**Mobile** (`use-onboarding.ts`):
- The onboarding enable-push action relied on the forced re-enable side effect; it now sets the preference explicitly via `updateNotificationPreferences({ push_enabled: true })` after registering the device. The Settings toggle already did this.

## Tests

- 5 new cases on `registerPushToken` (new device, existing device kept disabled, unchanged device not rewritten, platform refresh, `push_enabled` preserved on refresh).
- Full API and mobile suites, mobile typecheck, lint, and API build all pass.

## Relationship with #179

#179 also touches `registerPushToken` (adds `installationId`), so this commit has been merged into that branch with the semantic resolution (`refreshPushDeviceMetadata` also backfills `installationId`, covered by a dedicated test there). Whichever PR lands first, the other merges cleanly; if #179 lands first, this PR becomes redundant and can be closed.

## Deployment note

The behavior change is server-side: it takes effect once the API is deployed, with no mobile app update required. Only the onboarding adjustment ships with the next mobile build.