### PR TITLE
fix(mobile): prevent session logout on cold-start notification click

### DIFF
--- a/apps/api/src/app/auth/auth.controller.ts
+++ b/apps/api/src/app/auth/auth.controller.ts
@@ -20,7 +20,7 @@ export class AuthController {
     private readonly accessTokenService: AccessTokenService,
     @Inject(oauthProviderRequirementsSymbol)
     private readonly oauthProvider: OAuthProviderRequirements
-  ) { }
+  ) {}
 
   @Throttle(ThrottleOptions.publicSensitive())
   @Get('tesla/login')

--- a/apps/mobile/src/core/App.tsx
+++ b/apps/mobile/src/core/App.tsx
@@ -9,7 +9,7 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { MobileShell } from './MobileShell';
 import { ThemeProvider, useTheme } from './theme';
-import { initializeRuntimeConfig, tokenStore } from './api';
+import { initializeRuntimeConfig, sessionValidator, tokenStore } from './api';
 import { appLogger, installGlobalErrorLogging } from './logging';
 import { openTeslaApp } from './tesla-app-link';
 import { pushNotificationService } from '../features/notifications/di';
@@ -109,8 +109,6 @@ async function handleAlertNotificationResponse(
   response: Notifications.NotificationResponse,
   queryClient: QueryClient
 ): Promise<void> {
-  void queryClient.invalidateQueries({ queryKey: ['alerts'] });
-
   if (response.actionIdentifier !== Notifications.DEFAULT_ACTION_IDENTIFIER) {
     return;
   }
@@ -121,6 +119,14 @@ async function handleAlertNotificationResponse(
   }
 
   Notifications.clearLastNotificationResponse();
+
+  try {
+    await sessionValidator.ensureSessionValid();
+    void queryClient.invalidateQueries({ queryKey: ['alerts'] });
+  } catch (error) {
+    appLogger.error('api', 'Failed to validate session before notification response', error);
+  }
+
   await openTeslaApp(teslaRedirectUrl);
 }
 

--- a/apps/mobile/src/core/api/index.ts
+++ b/apps/mobile/src/core/api/index.ts
@@ -4,17 +4,24 @@ import { SecureStorage } from '../storage/secure-storage';
 import { ApiClient } from './api-client';
 import { ApiUrlStore } from './api-url-store';
 import { TokenStore } from './token-store';
+import { SessionValidator } from '../session/session-validator';
 
 export const secureStorage = new SecureStorage();
 export const tokenStore = new TokenStore(secureStorage);
 export const apiUrlStore = new ApiUrlStore(secureStorage);
 export const virtualKeyStore = new VirtualKeyStore(secureStorage);
 export const apiClient = new ApiClient(tokenStore, apiUrlStore, appLogger);
+export const sessionValidator = new SessionValidator(apiClient, tokenStore);
 
 export async function initializeRuntimeConfig(): Promise<void> {
-  await Promise.all([apiUrlStore.initialize(), virtualKeyStore.initialize()]);
+  await Promise.all([
+    apiUrlStore.initialize(),
+    virtualKeyStore.initialize(),
+    tokenStore.loadFromStorage(),
+  ]);
 }
 
 export * from './api-client';
 export * from './token-store';
 export * from './api-url-store';
+export * from '../session/session-validator';

--- a/apps/mobile/src/core/session/session-validator.test.ts
+++ b/apps/mobile/src/core/session/session-validator.test.ts
@@ -1,0 +1,41 @@
+import { mock, MockProxy } from 'jest-mock-extended';
+
+import { ApiClientRequirements } from '../api/api-client';
+import { TokenStoreRequirements } from '../api/token-store';
+import { SessionValidator } from './session-validator';
+
+describe('The SessionValidator class', () => {
+  let mockApiClient: MockProxy<ApiClientRequirements>;
+  let mockTokenStore: MockProxy<TokenStoreRequirements>;
+  let sessionValidator: SessionValidator;
+
+  beforeEach(() => {
+    mockApiClient = mock<ApiClientRequirements>();
+    mockTokenStore = mock<TokenStoreRequirements>();
+    sessionValidator = new SessionValidator(mockApiClient, mockTokenStore);
+  });
+
+  describe('The ensureSessionValid() method', () => {
+    describe('When there is no stored token', () => {
+      beforeEach(async () => {
+        mockTokenStore.getToken.mockReturnValue(null);
+        await sessionValidator.ensureSessionValid();
+      });
+
+      it('should not call the API client', () => {
+        expect(mockApiClient.request).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('When there is a stored token', () => {
+      beforeEach(async () => {
+        mockTokenStore.getToken.mockReturnValue('valid-token');
+        await sessionValidator.ensureSessionValid();
+      });
+
+      it('should call the language endpoint to validate the session', () => {
+        expect(mockApiClient.request).toHaveBeenCalledWith('/user/language');
+      });
+    });
+  });
+});

--- a/apps/mobile/src/core/session/session-validator.ts
+++ b/apps/mobile/src/core/session/session-validator.ts
@@ -1,0 +1,15 @@
+import { ApiClientRequirements } from '../api/api-client';
+import { TokenStoreRequirements } from '../api/token-store';
+
+export class SessionValidator {
+  public constructor(
+    private readonly apiClient: ApiClientRequirements,
+    private readonly tokenStore: TokenStoreRequirements
+  ) {}
+
+  public async ensureSessionValid(): Promise<void> {
+    if (this.tokenStore.getToken()) {
+      await this.apiClient.request('/user/language');
+    }
+  }
+}


### PR DESCRIPTION
### Problem
When the app is opened from a push notification (Cold Start), SentryGuard immediately triggers the deep link redirect to the Tesla App (`openTeslaApp`). 
Because this redirect backgrounds SentryGuard instantly, any in-flight session token refresh requests (triggered by the initial screen mounts) are terminated by the OS. This leaves SentryGuard with an expired token, causing the user to be logged out on the next launch.

### Solution
1. **Session Validator**: Introduced a `SessionValidator` service that performs a lightweight API request (`/user/language`) to trigger and await any required token refresh in the foreground before the redirect to the Tesla App is allowed to execute.
2. **App Boot Integration**: Integrated the validator into the boot flow, ensuring the token is loaded and checked in the foreground before SentryGuard is backgrounded.
3. **Unit Tests**: Added `session-validator.test.ts` to verify the validator logic in both authenticated and unauthenticated states.
