### PR TITLE
fix(security): phase 2 hardening batch

### DIFF
--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -170,9 +170,7 @@ Create these DNS records pointing to your server:
 | `fleet-telemetry.yourdomain.com` | A    | Your server IP |
 
 > [!IMPORTANT]
-> **Domain Matching Requirement**: The Webapp (`yourdomain.com`) and API (`api.yourdomain.com`) **must share the same registrable parent domain** (eTLD+1). The application uses a secure cookie flow for authentication; browsers will reject cookies set across different domains (e.g., `sentryguard.com` and `sentryguard-api.net`).
->
-> If you use complex or compound TLDs (e.g. `.co.uk`, `.com.br`), you may need to configure `COOKIE_DOMAIN` explicitly.
+> **Domain Matching Requirement**: The Webapp (`yourdomain.com`) and API (`api.yourdomain.com`) **must share the same registrable parent domain** (eTLD+1). The application uses a secure httpOnly cookie flow for authentication; browsers will not send the cookie on cross-site requests (e.g., `sentryguard.com` and `sentryguard-api.net`).
 
 > **Important**: If you use Cloudflare, set `fleet-telemetry.yourdomain.com` to **DNS only** (grey cloud). Cloudflare's proxy does not handle TLS connections on custom ports.
 
@@ -631,8 +629,6 @@ docker exec sentryguard-kafka kafka-topics --bootstrap-server localhost:9092 \
 | `TESLA_KEY_NAME`                       | `sentryguard`                                 | Name for the virtual key registration            |
 | `SENTRY_MODE_INTERVAL_SECONDS`         | `30`                                          | Sentry mode telemetry interval                   |
 | `BREAK_IN_MONITORING_INTERVAL_SECONDS` | `30`                                          | Break-in monitoring interval                     |
-| `COOKIE_DOMAIN`                        | Computed domain (eTLD+1)                      | Custom parent domain for authentication cookies  |
-| `NEXT_PUBLIC_COOKIE_DOMAIN`            | Computed domain (eTLD+1)                      | Custom parent domain for cookie clearing (webapp)|
 
 ---
 

--- a/apps/api/src/app/auth/auth.controller.spec.ts
+++ b/apps/api/src/app/auth/auth.controller.spec.ts
@@ -1,4 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { UnauthorizedException } from '@nestjs/common';
+import { Request, Response } from 'express';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { AccessTokenService } from './services/access-token.service';
@@ -251,6 +253,51 @@ describe('The AuthController class', () => {
 
     it('should reject missing bearer tokens', async () => {
       await expect(controller.refreshSession()).rejects.toThrow('No Bearer token provided');
+    });
+  });
+
+  describe('The exchangeSession() method', () => {
+    const buildRequest = (cookie?: string) =>
+      ({ headers: { cookie } }) as unknown as Request;
+    const buildResponse = () =>
+      ({ clearCookie: jest.fn() }) as unknown as Response;
+
+    describe('When no temp session cookie is present', () => {
+      it('should reject with an UnauthorizedException', async () => {
+        await expect(
+          controller.exchangeSession(buildRequest(undefined), buildResponse())
+        ).rejects.toThrow(UnauthorizedException);
+      });
+    });
+
+    describe('When the temp session token is invalid', () => {
+      it('should reject with an UnauthorizedException', async () => {
+        mockAuthService.validateJwtToken.mockResolvedValue(null);
+
+        await expect(
+          controller.exchangeSession(
+            buildRequest('sentryguard_temp_token=invalid-jwt'),
+            buildResponse()
+          )
+        ).rejects.toThrow(UnauthorizedException);
+      });
+    });
+
+    describe('When the temp session token is valid', () => {
+      it('should return the token and clear the cookie', async () => {
+        mockAuthService.validateJwtToken.mockResolvedValue({ userId: 'test-user-id' });
+        const response = buildResponse();
+
+        const result = await controller.exchangeSession(
+          buildRequest('other=1; sentryguard_temp_token=valid-jwt; third=2'),
+          response
+        );
+
+        expect(result).toStrictEqual({ token: 'valid-jwt' });
+        expect(response.clearCookie).toHaveBeenCalledWith('sentryguard_temp_token', {
+          path: '/auth/session',
+        });
+      });
     });
   });
 });

--- a/apps/api/src/app/auth/auth.controller.ts
+++ b/apps/api/src/app/auth/auth.controller.ts
@@ -1,5 +1,6 @@
-import { Controller, Get, Inject, Logger, Post, UnauthorizedException, UseGuards, Headers, Query } from '@nestjs/common';
+import { Controller, Get, HttpCode, Inject, Logger, Post, Req, Res, UnauthorizedException, UseGuards, Headers, Query } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
+import type { Request, Response } from 'express';
 import { AuthService } from './auth.service';
 import { AccessTokenService } from './services/access-token.service';
 import type { OAuthProviderRequirements } from './interfaces/oauth-provider.requirements';
@@ -137,6 +138,24 @@ export class AuthController {
     return { success: true, userId: user.userId, ...session };
   }
 
+  @Throttle(ThrottleOptions.publicSensitive())
+  @HttpCode(200)
+  @Post('session/exchange')
+  async exchangeSession(
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response
+  ): Promise<{ token: string }> {
+    const tempToken = this.extractTempSessionCookie(req);
+
+    if (!tempToken || !(await this.authService.validateJwtToken(tempToken))) {
+      throw new UnauthorizedException('Invalid or expired session');
+    }
+
+    res.clearCookie('sentryguard_temp_token', { path: '/auth/session' });
+
+    return { token: tempToken };
+  }
+
   @Throttle(ThrottleOptions.authenticatedRead())
   @Get('validate')
   async validateToken(
@@ -217,5 +236,15 @@ export class AuthController {
     }
 
     return authorization.substring(7);
+  }
+
+  private extractTempSessionCookie(req: Request): string | undefined {
+    const prefix = 'sentryguard_temp_token=';
+    const entry = req.headers.cookie
+      ?.split(';')
+      .map((part) => part.trim())
+      .find((part) => part.startsWith(prefix));
+
+    return entry ? decodeURIComponent(entry.substring(prefix.length)) : undefined;
   }
 }

--- a/apps/api/src/app/auth/callback.controller.spec.ts
+++ b/apps/api/src/app/auth/callback.controller.spec.ts
@@ -124,17 +124,16 @@ describe('The CallbackController class', () => {
           );
         });
 
-        it('should set a temporary cookie with the JWT token', () => {
+        it('should set a temporary httpOnly cookie with the JWT token', () => {
           expect(mockResponse.cookie).toHaveBeenCalledWith(
             'sentryguard_temp_token',
             mockJwt,
             expect.objectContaining({
-              httpOnly: false,
+              httpOnly: true,
               secure: false,
-              sameSite: 'lax',
-              path: '/',
+              sameSite: 'strict',
+              path: '/auth/session',
               maxAge: 60000,
-              domain: undefined,
             })
           );
         });

--- a/apps/api/src/app/auth/callback.controller.ts
+++ b/apps/api/src/app/auth/callback.controller.ts
@@ -66,19 +66,16 @@ export class CallbackController {
       }
 
       const webappUrl = process.env.WEBAPP_URL || 'http://localhost:4200';
-      const redirectUrl = `${webappUrl}/callback`;
-      const domain = this.getCookieDomain(webappUrl);
 
       res.cookie('sentryguard_temp_token', jwt, {
-        httpOnly: false,
+        httpOnly: true,
         secure: process.env.NODE_ENV === 'production',
-        sameSite: 'lax',
-        path: '/',
+        sameSite: 'strict',
+        path: '/auth/session',
         maxAge: 60 * 1000,
-        domain,
       });
 
-      res.redirect(redirectUrl);
+      res.redirect(`${webappUrl}/callback`);
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
 
@@ -107,35 +104,6 @@ export class CallbackController {
       const webappUrl = process.env.WEBAPP_URL || 'http://localhost:4200';
       const redirectUrl = `${webappUrl}/callback?error=${encodeURIComponent(errorMessage)}`;
       res.redirect(redirectUrl);
-    }
-  }
-
-  private getCookieDomain(webappUrl: string): string | undefined {
-    if (process.env.COOKIE_DOMAIN) {
-      return process.env.COOKIE_DOMAIN;
-    }
-
-    try {
-      const parsed = new URL(webappUrl);
-      const hostname = parsed.hostname;
-
-      if (hostname === 'localhost' || hostname === '127.0.0.1' || /^[0-9.]+$/.test(hostname)) {
-        return undefined;
-      }
-
-      const parts = hostname.split('.');
-      if (parts.length <= 2) {
-        return `.${hostname}`;
-      }
-
-      const secondLevelCcTlds = new Set(['co', 'com', 'org', 'net', 'gov', 'edu', 'ac']);
-      const isCompoundTld = parts.length >= 3 && secondLevelCcTlds.has(parts[parts.length - 2]);
-
-      return isCompoundTld
-        ? `.${parts.slice(-3).join('.')}`
-        : `.${parts.slice(-2).join('.')}`;
-    } catch {
-      return undefined;
     }
   }
 }

--- a/apps/api/src/app/consent/consent.controller.ts
+++ b/apps/api/src/app/consent/consent.controller.ts
@@ -8,11 +8,13 @@ import {
   Logger,
   Query,
 } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { ConsentService } from './consent.service';
 import type { ConsentData, ConsentStatus, ConsentTextResponse } from './consent.service';
 import type { User } from '../../entities/user.entity';
+import { ThrottleOptions } from '../../config/throttle.config';
 
 @Controller('consent')
 export class ConsentController {
@@ -63,6 +65,7 @@ export class ConsentController {
     };
   }
 
+  @Throttle(ThrottleOptions.critical())
   @Post('revoke')
   @UseGuards(JwtAuthGuard)
   async revokeConsent(@CurrentUser() user: User): Promise<{ success: boolean; message: string }> {

--- a/apps/api/src/app/telegram/telegram-webhook.controller.spec.ts
+++ b/apps/api/src/app/telegram/telegram-webhook.controller.spec.ts
@@ -1,0 +1,135 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { mock, MockProxy } from 'jest-mock-extended';
+import { Request, Response } from 'express';
+import { TelegramWebhookController } from './telegram-webhook.controller';
+import { TelegramBotService } from './telegram-bot.service';
+
+describe('The TelegramWebhookController class', () => {
+  let controller: TelegramWebhookController;
+  let mockTelegramBotService: MockProxy<TelegramBotService>;
+  let mockRequest: MockProxy<Request>;
+  let mockResponse: MockProxy<Response>;
+
+  beforeEach(async () => {
+    mockTelegramBotService = mock<TelegramBotService>();
+    mockRequest = mock<Request>();
+    mockResponse = mock<Response>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TelegramWebhookController],
+      providers: [
+        { provide: TelegramBotService, useValue: mockTelegramBotService },
+      ],
+    }).compile();
+
+    controller = module.get<TelegramWebhookController>(
+      TelegramWebhookController
+    );
+  });
+
+  describe('The handleWebhook() method', () => {
+    describe('When the path secret is invalid', () => {
+      it('should throw a NotFoundException', async () => {
+        mockTelegramBotService.getWebhookSecretPath.mockReturnValue(
+          'expected-secret'
+        );
+
+        await expect(
+          controller.handleWebhook('wrong--secret', mockRequest, mockResponse)
+        ).rejects.toThrow(NotFoundException);
+      });
+    });
+
+    describe('When the path secret has a different length', () => {
+      it('should throw a NotFoundException', async () => {
+        mockTelegramBotService.getWebhookSecretPath.mockReturnValue(
+          'expected-secret'
+        );
+
+        await expect(
+          controller.handleWebhook('short', mockRequest, mockResponse)
+        ).rejects.toThrow(NotFoundException);
+      });
+    });
+
+    describe('When the path secret is valid and no header secret is configured', () => {
+      it('should delegate the update to the bot service', async () => {
+        mockTelegramBotService.getWebhookSecretPath.mockReturnValue(
+          'expected-secret'
+        );
+        mockTelegramBotService.getWebhookSecretToken.mockReturnValue(undefined);
+
+        await controller.handleWebhook(
+          'expected-secret',
+          mockRequest,
+          mockResponse
+        );
+
+        expect(mockTelegramBotService.handleUpdate).toHaveBeenCalledWith(
+          mockRequest,
+          mockResponse
+        );
+      });
+    });
+
+    describe('When the header secret is invalid', () => {
+      it('should throw a ForbiddenException', async () => {
+        mockTelegramBotService.getWebhookSecretPath.mockReturnValue(
+          'expected-secret'
+        );
+        mockTelegramBotService.getWebhookSecretToken.mockReturnValue(
+          'header-secret'
+        );
+        mockRequest.headers = {
+          'x-telegram-bot-api-secret-token': 'wrong--header',
+        };
+
+        await expect(
+          controller.handleWebhook('expected-secret', mockRequest, mockResponse)
+        ).rejects.toThrow(ForbiddenException);
+      });
+    });
+
+    describe('When the header secret is missing', () => {
+      it('should throw a ForbiddenException', async () => {
+        mockTelegramBotService.getWebhookSecretPath.mockReturnValue(
+          'expected-secret'
+        );
+        mockTelegramBotService.getWebhookSecretToken.mockReturnValue(
+          'header-secret'
+        );
+        mockRequest.headers = {};
+
+        await expect(
+          controller.handleWebhook('expected-secret', mockRequest, mockResponse)
+        ).rejects.toThrow(ForbiddenException);
+      });
+    });
+
+    describe('When both secrets are valid', () => {
+      it('should delegate the update to the bot service', async () => {
+        mockTelegramBotService.getWebhookSecretPath.mockReturnValue(
+          'expected-secret'
+        );
+        mockTelegramBotService.getWebhookSecretToken.mockReturnValue(
+          'header-secret'
+        );
+        mockRequest.headers = {
+          'x-telegram-bot-api-secret-token': 'header-secret',
+        };
+
+        await controller.handleWebhook(
+          'expected-secret',
+          mockRequest,
+          mockResponse
+        );
+
+        expect(mockTelegramBotService.handleUpdate).toHaveBeenCalledWith(
+          mockRequest,
+          mockResponse
+        );
+      });
+    });
+  });
+});

--- a/apps/api/src/app/telegram/telegram-webhook.controller.ts
+++ b/apps/api/src/app/telegram/telegram-webhook.controller.ts
@@ -9,8 +9,8 @@ import {
   Logger,
   HttpCode,
 } from '@nestjs/common';
-import { Request, Response } from 'express';
-import * as crypto from 'crypto';
+import type { Request, Response } from 'express';
+import { timingSafeEqual } from 'node:crypto';
 import { TelegramBotService } from './telegram-bot.service';
 
 @Controller('telegram')
@@ -27,32 +27,18 @@ export class TelegramWebhookController {
     @Res() res: Response
   ) {
     const expectedSecret = this.telegramBotService.getWebhookSecretPath();
-    try {
-      const isPathMatch = crypto.timingSafeEqual(
-        Buffer.from(secret),
-        Buffer.from(expectedSecret)
-      );
-      if (!isPathMatch) throw new Error();
-    } catch {
-      this.logger.warn(`Tentative webhook avec secret invalide`);
+    if (!this.isSecretValid(secret, expectedSecret)) {
+      this.logger.warn('Tentative webhook avec secret invalide');
       throw new NotFoundException();
     }
 
     const headerSecret = this.telegramBotService.getWebhookSecretToken();
     if (headerSecret) {
       const provided = req.headers['x-telegram-bot-api-secret-token'];
-      if (!provided || typeof provided !== 'string') {
-        this.logger.warn('Tentative webhook avec secret token manquant ou invalide');
-        throw new ForbiddenException();
-      }
-
-      try {
-        const isHeaderMatch = crypto.timingSafeEqual(
-          Buffer.from(provided),
-          Buffer.from(headerSecret)
-        );
-        if (!isHeaderMatch) throw new Error();
-      } catch {
+      if (
+        typeof provided !== 'string' ||
+        !this.isSecretValid(provided, headerSecret)
+      ) {
         this.logger.warn('Tentative webhook avec secret token invalide');
         throw new ForbiddenException();
       }
@@ -60,6 +46,14 @@ export class TelegramWebhookController {
 
     return this.telegramBotService.handleUpdate(req, res);
   }
+
+  private isSecretValid(provided: string, expected: string): boolean {
+    const providedBuffer = Buffer.from(provided);
+    const expectedBuffer = Buffer.from(expected);
+
+    return (
+      providedBuffer.length === expectedBuffer.length &&
+      timingSafeEqual(providedBuffer, expectedBuffer)
+    );
+  }
 }
-
-

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -34,15 +34,17 @@ async function bootstrap() {
     .split(',')
     .map((origin) => origin.trim())
     .filter((origin) => origin.length > 0);
+  const developmentOrigins =
+    process.env.NODE_ENV === 'production'
+      ? []
+      : [
+          'http://localhost:4200',
+          'http://localhost:3000',
+          'http://localhost:8081',
+          'http://localhost:19006',
+        ];
   const baseOrigins: Array<string> = Array.from(
-    new Set([
-      webappUrl,
-      'http://localhost:4200',
-      'http://localhost:3000',
-      'http://localhost:8081',
-      'http://localhost:19006',
-      ...additionalOrigins,
-    ])
+    new Set([webappUrl, ...developmentOrigins, ...additionalOrigins])
   );
 
   const originRegex = /^https?:\/\/[a-zA-Z0-9.-]+(:\d+)?$/;

--- a/apps/webapp/src/app/callback/use-tesla-callback.test.ts
+++ b/apps/webapp/src/app/callback/use-tesla-callback.test.ts
@@ -2,6 +2,7 @@ import { renderHook, act } from '@testing-library/react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { useTeslaCallback } from './use-tesla-callback';
 import { setToken, hasToken } from '../../core/api/token-manager';
+import { apiClient } from '../../core/api';
 import { getConsentStatusUseCase } from '../../features/consent/di';
 
 jest.mock('next/navigation', () => ({
@@ -12,6 +13,10 @@ jest.mock('next/navigation', () => ({
 jest.mock('../../core/api/token-manager', () => ({
   setToken: jest.fn(),
   hasToken: jest.fn(),
+}));
+
+jest.mock('../../core/api', () => ({
+  apiClient: { request: jest.fn() },
 }));
 
 jest.mock('../../features/consent/di', () => ({
@@ -49,8 +54,6 @@ describe('The useTeslaCallback() hook', () => {
 
     window.location.hash = '';
     window.location.search = '';
-
-    document.cookie = 'sentryguard_temp_token=; expires=Thu, 01 Jan 1970 00:00:00 GMT';
   });
 
   afterEach(() => {
@@ -99,27 +102,45 @@ describe('The useTeslaCallback() hook', () => {
     });
   });
 
-  describe('When a temp token cookie is present', () => {
+  describe('When the session exchange succeeds', () => {
     beforeEach(() => {
-      document.cookie = 'sentryguard_temp_token=test-temp-jwt';
+      (apiClient.request as jest.Mock).mockResolvedValue({ token: 'exchanged-jwt' });
       (hasToken as jest.Mock).mockReturnValue(true);
       (getConsentStatusUseCase.execute as jest.Mock).mockResolvedValue({ hasConsent: true });
     });
 
-    it('should store the token', async () => {
+    it('should store the exchanged token', async () => {
       renderHook(() => useTeslaCallback());
       await act(async () => {
         await flushMicrotasks();
       });
-      expect(setToken).toHaveBeenCalledWith('test-temp-jwt');
+      expect(setToken).toHaveBeenCalledWith('exchanged-jwt');
     });
 
-    it('should delete the cookie', async () => {
+    it('should call the exchange endpoint with credentials included', async () => {
       renderHook(() => useTeslaCallback());
       await act(async () => {
         await flushMicrotasks();
       });
-      expect(document.cookie).not.toContain('sentryguard_temp_token=test-temp-jwt');
+      expect(apiClient.request).toHaveBeenCalledWith(
+        '/auth/session/exchange',
+        expect.objectContaining({ method: 'POST', credentials: 'include' })
+      );
+    });
+  });
+
+  describe('When the session exchange fails', () => {
+    beforeEach(() => {
+      (apiClient.request as jest.Mock).mockRejectedValue(new Error('Unauthorized'));
+      (hasToken as jest.Mock).mockReturnValue(false);
+    });
+
+    it('should set status to error', async () => {
+      const { result } = renderHook(() => useTeslaCallback());
+      await act(async () => {
+        await flushMicrotasks();
+      });
+      expect(result.current.status).toStrictEqual('error');
     });
   });
 
@@ -141,6 +162,7 @@ describe('The useTeslaCallback() hook', () => {
 
   describe('When authentication is successful and user has consent', () => {
     beforeEach(() => {
+      (apiClient.request as jest.Mock).mockResolvedValue({ token: 'exchanged-jwt' });
       (hasToken as jest.Mock).mockReturnValue(true);
       (getConsentStatusUseCase.execute as jest.Mock).mockResolvedValue({ hasConsent: true });
     });
@@ -159,6 +181,7 @@ describe('The useTeslaCallback() hook', () => {
 
   describe('When authentication is successful and user does not have consent', () => {
     beforeEach(() => {
+      (apiClient.request as jest.Mock).mockResolvedValue({ token: 'exchanged-jwt' });
       (hasToken as jest.Mock).mockReturnValue(true);
       (getConsentStatusUseCase.execute as jest.Mock).mockResolvedValue({ hasConsent: false });
     });
@@ -177,6 +200,7 @@ describe('The useTeslaCallback() hook', () => {
 
   describe('When no token is received', () => {
     beforeEach(() => {
+      (apiClient.request as jest.Mock).mockRejectedValue(new Error('Unauthorized'));
       (hasToken as jest.Mock).mockReturnValue(false);
     });
 

--- a/apps/webapp/src/app/callback/use-tesla-callback.ts
+++ b/apps/webapp/src/app/callback/use-tesla-callback.ts
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { setToken, hasToken } from '../../core/api/token-manager';
+import { apiClient } from '../../core/api';
 import { getConsentStatusUseCase } from '../../features/consent/di';
 
 interface CallbackParams {
@@ -9,58 +10,22 @@ interface CallbackParams {
   error: string | null;
 }
 
-function getCookie(name: string): string | null {
-  if (typeof document === 'undefined') return null;
-  const value = `; ${document.cookie}`;
-  const parts = value.split(`; ${name}=`);
-  if (parts.length === 2) return parts.pop()?.split(';').shift() || null;
-  return null;
-}
-
-function getCookieDomain(): string | undefined {
-  if (typeof window === 'undefined') return undefined;
-
-  if (process.env.NEXT_PUBLIC_COOKIE_DOMAIN) {
-    return process.env.NEXT_PUBLIC_COOKIE_DOMAIN;
+async function exchangeSessionToken(): Promise<string | null> {
+  try {
+    const { token } = await apiClient.request<{ token: string }>(
+      '/auth/session/exchange',
+      { method: 'POST', credentials: 'include' }
+    );
+    return token ?? null;
+  } catch {
+    return null;
   }
-
-  const hostname = window.location.hostname;
-  if (hostname === 'localhost' || hostname === '127.0.0.1' || /^[0-9.]+$/.test(hostname)) {
-    return undefined;
-  }
-
-  const parts = hostname.split('.');
-  if (parts.length <= 2) {
-    return `.${hostname}`;
-  }
-
-  const secondLevelCcTlds = new Set(['co', 'com', 'org', 'net', 'gov', 'edu', 'ac']);
-  const isCompoundTld = parts.length >= 3 && secondLevelCcTlds.has(parts[parts.length - 2]);
-
-  return isCompoundTld
-    ? `.${parts.slice(-3).join('.')}`
-    : `.${parts.slice(-2).join('.')}`;
-}
-
-function deleteCookie(name: string): void {
-  if (typeof document === 'undefined') return;
-  const domain = getCookieDomain();
-  let cookieString = `${name}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
-  if (domain) {
-    cookieString += `; domain=${domain}`;
-  }
-  document.cookie = cookieString;
 }
 
 function parseCallbackParams(searchParams: URLSearchParams): CallbackParams {
   const error = searchParams.get('error');
   if (error) {
     return { token: null, error };
-  }
-
-  const cookieToken = getCookie('sentryguard_temp_token');
-  if (cookieToken) {
-    return { token: cookieToken, error: null };
   }
 
   const hash = typeof window !== 'undefined' ? window.location.hash : '';
@@ -142,9 +107,10 @@ export function useTeslaCallback() {
         return;
       }
 
-      if (token) {
-        storeToken(token);
-        deleteCookie('sentryguard_temp_token');
+      const sessionToken = token ?? (await exchangeSessionToken());
+
+      if (sessionToken) {
+        storeToken(sessionToken);
       }
 
       if (hasToken()) {

--- a/apps/webapp/src/app/callback/use-tesla-callback.ts
+++ b/apps/webapp/src/app/callback/use-tesla-callback.ts
@@ -66,6 +66,7 @@ export function useTeslaCallback() {
   const [message, setMessage] = useState(t('Processing authentication...'));
 
   const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const exchangeAttempted = useRef(false);
 
   const handleError = useCallback((error: string) => {
     if (error === 'login_cancelled') {
@@ -100,6 +101,9 @@ export function useTeslaCallback() {
 
   useEffect(() => {
     const handleCallback = async () => {
+      if (exchangeAttempted.current) return;
+      exchangeAttempted.current = true;
+
       const { token, error } = parseCallbackParams(searchParams);
 
       if (error) {


### PR DESCRIPTION
## Summary

Second phase of the security hardening program (follow-up to `346bd15`). Closes the CORS `localhost` finding (contre-expertise F2 / P2-6) and removes the last JavaScript-readable token window in the web OAuth flow.

## Changes

### Auth cookie flow (api + webapp)
- The temporary OAuth callback token (`sentryguard_temp_token`) is now `httpOnly: true`, `sameSite: 'strict'`, scoped to `path: '/auth/session'`, and host-only (no `Domain` attribute) — it is no longer readable by JavaScript or by sibling subdomains during its 60s lifetime.
- New `POST /auth/session/exchange` endpoint: reads the httpOnly cookie server-side, validates the JWT, clears the cookie, and returns the token in the response body (throttled with `publicSensitive`).
- The webapp callback exchanges the cookie via `apiClient.request(..., { credentials: 'include' })` instead of reading/deleting it from `document.cookie`.
- Removed the now-unused `getCookieDomain` heuristics and the `COOKIE_DOMAIN` / `NEXT_PUBLIC_COOKIE_DOMAIN` environment variables (docs updated accordingly in `SELF_HOSTING.md`).

### CORS (api)
- `localhost:4200/3000/8081/19006` origins are only allowed when `NODE_ENV !== 'production'` — a local service on a victim's machine no longer gets an authorized credentialed origin in production.

### Consent (api)
- `POST /consent/revoke` is now throttled with the `critical` policy (it calls the Tesla partner API to delete the vehicle telemetry configuration).

### Telegram webhook (api)
- Both secret comparisons now go through a single constant-time `isSecretValid()` helper (`node:crypto` `timingSafeEqual` + explicit length pre-check), replacing the try/catch control flow. Covered by a new dedicated spec (6 cases: wrong/short path secret, missing/wrong/valid header secret, delegation).

## Testing

- `nx run-many -t lint --projects=api,webapp` ✅
- `nx run-many -t test --projects=api,webapp --skip-nx-cache` ✅ (including new specs for `exchangeSession`, the callback cookie attributes, the session-exchange hook flow, and the webhook controller)

## Notes

- The private security docs (`SECURITY_ARCHITECTURE.md` §4.1, `SECURITY_RECOMMENDATIONS.md` P2-6 + Recently Completed) need a follow-up update after merge.