### PR TITLE
fix: parallelize push notifications and force high priority (resolves #206)

### DIFF
--- a/apps/api/src/app/alerts/common/vehicle-alert-notifier.service.spec.ts
+++ b/apps/api/src/app/alerts/common/vehicle-alert-notifier.service.spec.ts
@@ -199,13 +199,15 @@ describe('The VehicleAlertNotifierService class', () => {
           'user-1',
           AlertEventSeverity.Critical,
           AlertEventType.BreakIn,
-          'en'
+          'en',
+          'corr-123'
         );
         expect(mockNotificationsService.sendPushAlert).toHaveBeenCalledWith(
           'user-2',
           AlertEventSeverity.Critical,
           AlertEventType.BreakIn,
-          'fr'
+          'fr',
+          'corr-123'
         );
       });
     });
@@ -227,7 +229,8 @@ describe('The VehicleAlertNotifierService class', () => {
           'user-1',
           AlertEventSeverity.Critical,
           AlertEventType.BreakIn,
-          'en'
+          'en',
+          'corr-123'
         );
       });
     });

--- a/apps/api/src/app/alerts/common/vehicle-alert-notifier.service.ts
+++ b/apps/api/src/app/alerts/common/vehicle-alert-notifier.service.ts
@@ -130,18 +130,23 @@ export class VehicleAlertNotifierService {
     try {
       const userLanguage = await this.userLanguageService.getUserLanguage(userId);
 
-      const telegramStart = Date.now();
-      if (!config || await this.notificationsService.shouldSendTelegram(userId, config.severity)) {
-        await telegramNotifier(userId, alertInfo, userLanguage);
-      }
-      if (config) {
-        await this.notificationsService.sendPushAlert(userId, config.severity, config.type, userLanguage);
-      }
-      const telegramTime = Date.now() - telegramStart;
+      const pushTask = config
+        ? this.notificationsService.sendPushAlert(userId, config.severity, config.type, userLanguage, correlationId)
+        : Promise.resolve();
 
-      if (telegramTime > VehicleAlertNotifierService.TELEGRAM_SLOW_THRESHOLD_MS) {
-        this.logger.warn(`[TELEGRAM_SLOW][${correlationId}] ${alertName}: ${telegramTime}ms for user: ${userId}`);
-      }
+      const telegramTask = (async () => {
+        const telegramStart = Date.now();
+        if (!config || await this.notificationsService.shouldSendTelegram(userId, config.severity)) {
+          await telegramNotifier(userId, alertInfo, userLanguage);
+        }
+        const telegramTime = Date.now() - telegramStart;
+
+        if (telegramTime > VehicleAlertNotifierService.TELEGRAM_SLOW_THRESHOLD_MS) {
+          this.logger.warn(`[TELEGRAM_SLOW][${correlationId}] ${alertName}: ${telegramTime}ms for user: ${userId}`);
+        }
+      })();
+
+      await Promise.all([pushTask, telegramTask]);
 
       return { success: true, userId };
     } catch (error) {
@@ -177,7 +182,7 @@ export class VehicleAlertNotifierService {
     const handlerProcessingTime = Date.now() - handlerStartTime;
 
     if (endToEndLatency !== null) {
-      const isProcessingDelayed = telemetryMessage.isProcessingDelayed(handlerProcessingTime, 1000);
+      const isProcessingDelayed = telemetryMessage.isProcessingDelayed(handlerProcessingTime, 3000);
 
       if (isProcessingDelayed) {
         this.logger.error(`[${latencyLabel}] CorrelationId: ${telemetryMessage.correlationId} - DELAYED: ${endToEndLatency}ms (Handler: ${handlerProcessingTime}ms) ❌`);

--- a/apps/api/src/app/notifications/notifications.service.ts
+++ b/apps/api/src/app/notifications/notifications.service.ts
@@ -92,13 +92,19 @@ export class NotificationsService {
     userId: string,
     severity: AlertEventSeverity,
     type: AlertEventType,
-    userLanguage: 'en' | 'fr'
+    userLanguage: 'en' | 'fr',
+    correlationId?: string
   ): Promise<void> {
     const { body, title } = this.resolveAlertTexts(type, userLanguage);
     const devices = await this.pushDeviceTokenRepository.find({ where: { userId, push_enabled: true } });
     const eligibleDevices = devices.filter((device) => this.shouldSendPushToDevice(device, severity));
+
+    if (eligibleDevices.length > 0) {
+      this.logger.log(`[EXPO_PUSH][${correlationId || 'none'}] Sending push to ${eligibleDevices.length} device(s) for user: ${userId}`);
+    }
+
     await Promise.all(
-      eligibleDevices.map((device) => this.sendExpoPush(device, title, body, severity, type, device.critical_alerts_enabled, userId, userLanguage))
+      eligibleDevices.map((device) => this.sendExpoPush(device, title, body, severity, type, device.critical_alerts_enabled, userId, userLanguage, correlationId))
     );
   }
 
@@ -196,18 +202,23 @@ export class NotificationsService {
     type: AlertEventType,
     criticalAlertsEnabled: boolean,
     userId: string,
-    userLanguage: 'en' | 'fr'
+    userLanguage: 'en' | 'fr',
+    correlationId?: string
   ): Promise<void> {
     try {
+      const pushStart = Date.now();
       const response = await fetch('https://exp.host/--/api/v2/push/send', {
         body: JSON.stringify(this.buildExpoPushBody(device.token, title, body, severity, type, criticalAlertsEnabled, userId, userLanguage)),
         headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
         method: 'POST',
       });
+      
+      const pushTime = Date.now() - pushStart;
+      this.logger.log(`[EXPO_PUSH_LATENCY][${correlationId || 'none'}] Push sent to device ${device.id} in ${pushTime}ms`);
 
       await this.handleExpoPushResponse(device, response);
     } catch (error) {
-      this.logger.warn(`Failed to send push notification: ${error instanceof Error ? error.message : 'unknown error'}`);
+      this.logger.warn(`Failed to send push notification: ${error instanceof Error ? error.message : 'unknown error'} (correlation: ${correlationId || 'none'})`);
     }
   }
 
@@ -236,7 +247,7 @@ export class NotificationsService {
         teslaRedirectUrl: this.buildTeslaRedirectUrl(userId, userLanguage),
         type,
       },
-      priority: isPriorityAlert || severity === AlertEventSeverity.Critical ? 'high' : 'default',
+      priority: 'high',
       title,
       to: token,
     };


### PR DESCRIPTION
Resolves #206

### Why:
- Sentry and Break-in alerts were suffering from up to 20-30 minutes delays on iOS and Android for some users because notifications were sent with `priority: 'default'`. Apple's APNs and Google's FCM delay normal-priority notifications to conserve battery (Doze mode).
- The alert processing handler was also experiencing artificial latencies because it executed Telegram and Push notifications sequentially, taking over 1000ms combined.
- The `[TELEGRAM_SLOW]` telemetry metric incorrectly included the Push API latency, masking the real bottleneck.
- Frequent normal network fluctuations caused false-positive `DELAYED` logs due to an overly aggressive 1000ms threshold.

### How:
- Forced `priority: 'high'` in the Expo Push payload for all notifications to guarantee immediate delivery and wake up sleeping devices.
- Parallelized the Telegram and Push API calls using `Promise.all()` in `VehicleAlertNotifierService` to divide network wait times by two.
- Isolated the `telegramTime` measurement to only track the Telegram API call, ensuring accurate metrics.
- Increased the `isProcessingDelayed` threshold from 1000ms to 3000ms in `vehicle-alert-notifier.service.ts` to accommodate normal third-party API latency.
- Added `[EXPO_PUSH_LATENCY]` telemetry logs with the correlation ID to trace push API performance.
