### PR TITLE
fix(api): return proper HTTP error statuses on telemetry config failure

### DIFF
--- a/apps/api/src/app/telemetry/break-in-monitoring-config.service.spec.ts
+++ b/apps/api/src/app/telemetry/break-in-monitoring-config.service.spec.ts
@@ -1,3 +1,8 @@
+import {
+  BadGatewayException,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { mock, MockProxy } from 'jest-mock-extended';
@@ -33,13 +38,20 @@ describe('The BreakInMonitoringConfigService class', () => {
     const userId = 'user1';
 
     describe('When vehicle is missing', () => {
+      let act: () => Promise<unknown>;
+
       beforeEach(() => {
         mockVehicleRepository.findOne.mockResolvedValue(null);
+        act = async () => await service.toggleBreakInMonitoring(vin, userId, true);
       });
 
-      it('should return vehicle not found error', async () => {
-        const result = await service.toggleBreakInMonitoring(vin, userId, true);
-        expect(result).toEqual({ success: false, message: 'Vehicle not found' });
+      it('should throw a not found exception', async () => {
+        await expect(act()).rejects.toThrow(NotFoundException);
+      });
+
+      it('should not push any telemetry configuration', async () => {
+        await expect(act()).rejects.toThrow();
+        expect(mockTelemetryConfigService.patchTelemetryConfig).not.toHaveBeenCalled();
       });
     });
 
@@ -96,28 +108,43 @@ describe('The BreakInMonitoringConfigService class', () => {
     });
 
     describe('When patch fails', () => {
+      let act: () => Promise<unknown>;
+
       beforeEach(() => {
         const vehicle = { vin, userId, break_in_monitoring_enabled: true } as Vehicle;
         mockVehicleRepository.findOne.mockResolvedValue(vehicle);
         mockTelemetryConfigService.patchTelemetryConfig.mockResolvedValue({ success: false });
+        act = async () => await service.toggleBreakInMonitoring(vin, userId, true);
       });
 
-      it('should return error', async () => {
-        const result = await service.toggleBreakInMonitoring(vin, userId, true);
+      it('should throw a bad gateway exception', async () => {
+        await expect(act()).rejects.toThrow(BadGatewayException);
+      });
 
-        expect(result).toEqual({ success: false, message: 'Failed to push telemetry configuration to Tesla' });
+      it('should expose the Tesla push failure message', async () => {
+        await expect(act()).rejects.toThrow('Failed to push telemetry configuration to Tesla');
+      });
+
+      it('should not persist the vehicle', async () => {
+        await expect(act()).rejects.toThrow();
         expect(mockVehicleRepository.save).not.toHaveBeenCalled();
       });
     });
 
-    describe('When an exception occurs', () => {
+    describe('When an unexpected exception occurs', () => {
+      let act: () => Promise<unknown>;
+
       beforeEach(() => {
         mockVehicleRepository.findOne.mockRejectedValue(new Error('DB error'));
+        act = async () => await service.toggleBreakInMonitoring(vin, userId, true);
       });
 
-      it('should handle exceptions', async () => {
-        const result = await service.toggleBreakInMonitoring(vin, userId, true);
-        expect(result).toEqual({ success: false, message: 'An unexpected error occurred' });
+      it('should throw an internal server error exception', async () => {
+        await expect(act()).rejects.toThrow(InternalServerErrorException);
+      });
+
+      it('should not leak the underlying error message', async () => {
+        await expect(act()).rejects.toThrow('An unexpected error occurred');
       });
     });
   });

--- a/apps/api/src/app/telemetry/break-in-monitoring-config.service.ts
+++ b/apps/api/src/app/telemetry/break-in-monitoring-config.service.ts
@@ -1,10 +1,24 @@
-import { Injectable, Logger } from '@nestjs/common';
+import {
+  BadGatewayException,
+  HttpException,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { TelemetryConfigService } from './telemetry-config.service';
 import { Vehicle } from '../../entities/vehicle.entity';
 import { TELEMETRY_CONFIG } from './telemetry-config.constants';
 import { extractErrorDetails } from './telemetry-config.helpers';
+
+const BREAK_IN_MONITORED_FIELDS = ['CenterDisplay', 'ChargePortLatch'];
+
+export interface BreakInMonitoringToggleResult {
+  success: true;
+  message: string;
+}
 
 @Injectable()
 export class BreakInMonitoringConfigService {
@@ -16,52 +30,72 @@ export class BreakInMonitoringConfigService {
     private readonly vehicleRepository: Repository<Vehicle>
   ) { }
 
-  async toggleBreakInMonitoring(
+  public async toggleBreakInMonitoring(
     vin: string,
     userId: string,
     enabled: boolean
-  ): Promise<{ success: boolean; message: string }> {
+  ): Promise<BreakInMonitoringToggleResult> {
     try {
-      const vehicle = await this.getVehicle(userId, vin);
-      if (!vehicle) {
-        return { success: false, message: 'Vehicle not found' };
-      }
-
-      const fieldsToUpsert: Record<string, { interval_seconds: number }> = {};
-      const fieldsToDelete: string[] = [];
-
-      if (enabled) {
-        const breakInIntervalSeconds = parseInt(
-          process.env.BREAK_IN_MONITORING_INTERVAL_SECONDS ?? String(TELEMETRY_CONFIG.DEFAULT_BREAK_IN_MONITORING_INTERVAL),
-          10
-        );
-        fieldsToUpsert['CenterDisplay'] = { interval_seconds: breakInIntervalSeconds };
-        fieldsToUpsert['ChargePortLatch'] = { interval_seconds: breakInIntervalSeconds };
-      } else {
-        fieldsToDelete.push('CenterDisplay');
-        fieldsToDelete.push('ChargePortLatch');
-      }
-
-      const result = await this.telemetryConfigService.patchTelemetryConfig(
-        vin,
-        userId,
-        fieldsToUpsert,
-        fieldsToDelete
-      );
-
-      if (!result?.success) {
-        return { success: false, message: 'Failed to push telemetry configuration to Tesla' };
-      }
-
-      vehicle.break_in_monitoring_enabled = enabled;
-      await this.vehicleRepository.save(vehicle);
-      this.logger.log(`Break-in monitoring ${enabled ? 'enabled' : 'disabled'} for VIN: ${vin}`);
-
-      return { success: true, message: `Break-in monitoring ${enabled ? 'enabled' : 'disabled'} successfully` };
+      return await this.applyBreakInMonitoring(vin, userId, enabled);
     } catch (error: unknown) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+
       this.logger.error(`Error toggling break-in monitoring for ${vin}:`, extractErrorDetails(error));
-      return { success: false, message: 'An unexpected error occurred' };
+      throw new InternalServerErrorException('An unexpected error occurred');
     }
+  }
+
+  private async applyBreakInMonitoring(
+    vin: string,
+    userId: string,
+    enabled: boolean
+  ): Promise<BreakInMonitoringToggleResult> {
+    const vehicle = await this.getVehicle(userId, vin);
+
+    if (!vehicle) {
+      throw new NotFoundException('Vehicle not found');
+    }
+
+    await this.pushBreakInMonitoringFields(vin, userId, enabled);
+
+    vehicle.break_in_monitoring_enabled = enabled;
+    await this.vehicleRepository.save(vehicle);
+    this.logger.log(`Break-in monitoring ${enabled ? 'enabled' : 'disabled'} for VIN: ${vin}`);
+
+    return { success: true, message: `Break-in monitoring ${enabled ? 'enabled' : 'disabled'} successfully` };
+  }
+
+  private async pushBreakInMonitoringFields(vin: string, userId: string, enabled: boolean): Promise<void> {
+    const result = await this.telemetryConfigService.patchTelemetryConfig(
+      vin,
+      userId,
+      this.buildFieldsToUpsert(enabled),
+      enabled ? [] : [...BREAK_IN_MONITORED_FIELDS]
+    );
+
+    if (!result?.success) {
+      throw new BadGatewayException('Failed to push telemetry configuration to Tesla');
+    }
+  }
+
+  private buildFieldsToUpsert(enabled: boolean): Record<string, { interval_seconds: number }> {
+    if (!enabled) {
+      return {};
+    }
+
+    const interval_seconds = this.resolveMonitoringIntervalSeconds();
+
+    return Object.fromEntries(BREAK_IN_MONITORED_FIELDS.map((field) => [field, { interval_seconds }]));
+  }
+
+  private resolveMonitoringIntervalSeconds(): number {
+    return parseInt(
+      process.env.BREAK_IN_MONITORING_INTERVAL_SECONDS ??
+      String(TELEMETRY_CONFIG.DEFAULT_BREAK_IN_MONITORING_INTERVAL),
+      10
+    );
   }
 
   private async getVehicle(userId: string, vin: string): Promise<Vehicle | null> {

--- a/apps/api/src/app/telemetry/break-in-monitoring.controller.spec.ts
+++ b/apps/api/src/app/telemetry/break-in-monitoring.controller.spec.ts
@@ -1,7 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { mock, MockProxy } from 'jest-mock-extended';
 import { BreakInMonitoringController } from './break-in-monitoring.controller';
-import { BreakInMonitoringConfigService } from './break-in-monitoring-config.service';
+import {
+  BreakInMonitoringConfigService,
+  BreakInMonitoringToggleResult,
+} from './break-in-monitoring-config.service';
 import { User } from '../../entities/user.entity';
 
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
@@ -35,10 +38,10 @@ describe('The BreakInMonitoringController class', () => {
 
   describe('The enableFeature() method', () => {
     describe('When called with valid parameters', () => {
-      let result: { success: boolean; message: string };
+      let result: BreakInMonitoringToggleResult;
       const vin = 'VIN123';
       const user = { userId: 'user-1' } as User;
-      const expectedResult = { success: true, message: 'Enabled' };
+      const expectedResult: BreakInMonitoringToggleResult = { success: true, message: 'Enabled' };
 
       beforeEach(async () => {
         mockBreakInMonitoringConfigService.toggleBreakInMonitoring.mockResolvedValue(expectedResult);
@@ -57,10 +60,10 @@ describe('The BreakInMonitoringController class', () => {
 
   describe('The disableFeature() method', () => {
     describe('When called with valid parameters', () => {
-      let result: { success: boolean; message: string };
+      let result: BreakInMonitoringToggleResult;
       const vin = 'VIN123';
       const user = { userId: 'user-1' } as User;
-      const expectedResult = { success: true, message: 'Disabled' };
+      const expectedResult: BreakInMonitoringToggleResult = { success: true, message: 'Disabled' };
 
       beforeEach(async () => {
         mockBreakInMonitoringConfigService.toggleBreakInMonitoring.mockResolvedValue(expectedResult);

--- a/apps/api/src/app/telemetry/break-in-monitoring.controller.ts
+++ b/apps/api/src/app/telemetry/break-in-monitoring.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Post, Param, Logger, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Param,
+  Logger,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { BreakInMonitoringConfigService } from './break-in-monitoring-config.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
@@ -15,6 +23,7 @@ export class BreakInMonitoringController {
   constructor(private readonly breakInMonitoringConfigService: BreakInMonitoringConfigService) {}
 
   @Throttle(ThrottleOptions.critical())
+  @HttpCode(HttpStatus.OK)
   @Post(':vin/enable')
   async enableFeature(@Param('vin') vin: string, @CurrentUser() user: User) {
     this.logger.log(`🚗 Enabling break-in monitoring for VIN: ${vin} (user: ${user.userId})`);
@@ -22,6 +31,7 @@ export class BreakInMonitoringController {
   }
 
   @Throttle(ThrottleOptions.critical())
+  @HttpCode(HttpStatus.OK)
   @Post(':vin/disable')
   async disableFeature(@Param('vin') vin: string, @CurrentUser() user: User) {
     this.logger.log(`🚗 Disabling break-in monitoring for VIN: ${vin} (user: ${user.userId})`);

--- a/apps/api/src/app/telemetry/telemetry-config.controller.spec.ts
+++ b/apps/api/src/app/telemetry/telemetry-config.controller.spec.ts
@@ -1,3 +1,4 @@
+import { BadGatewayException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { TelemetryConfigController } from './telemetry-config.controller';
 import { TelemetryConfigService } from './telemetry-config.service';
@@ -24,6 +25,7 @@ describe('TelemetryConfigController', () => {
           useValue: {
             getVehicles: jest.fn(),
             checkTelemetryConfig: jest.fn(),
+            deleteTelemetryConfig: jest.fn(),
           },
         },
         {
@@ -127,18 +129,16 @@ describe('TelemetryConfigController', () => {
       });
     });
 
-    it('should return failed message when service returns null', async () => {
+    it('should throw a bad gateway exception when service returns null', async () => {
       const vin = 'TEST_VIN_123';
 
       (sentryModeConfigService.configureTelemetry as jest.Mock).mockResolvedValue(null);
 
       const mockUser = { userId: 'test-user-id' } as unknown as User;
 
-      const result = await controller.configureVehicle(vin, mockUser);
-
-      expect(result).toEqual({
-        message: `Configuration failed for VIN: ${vin}`,
-      });
+      await expect(controller.configureVehicle(vin, mockUser)).rejects.toThrow(
+        BadGatewayException
+      );
     });
 
     it('should handle service errors', async () => {
@@ -150,6 +150,33 @@ describe('TelemetryConfigController', () => {
       await expect(controller.configureVehicle(vin, mockUser)).rejects.toThrow(
         'Service error'
       );
+    });
+  });
+
+  describe('deleteTelemetryConfig', () => {
+    const vin = 'TEST_VIN_123';
+    const mockUser = { userId: 'test-user-id' } as unknown as User;
+
+    it('should return the deletion result when it succeeds', async () => {
+      const expectedResult = { success: true, message: 'Configuration deleted' };
+      jest
+        .spyOn(service, 'deleteTelemetryConfig')
+        .mockResolvedValue(expectedResult);
+
+      const result = await controller.deleteTelemetryConfig(vin, mockUser);
+
+      expect(result).toEqual(expectedResult);
+    });
+
+    it('should throw a bad gateway exception when the deletion fails', async () => {
+      jest.spyOn(service, 'deleteTelemetryConfig').mockResolvedValue({
+        success: false,
+        message: 'Error deleting telemetry configuration',
+      });
+
+      await expect(
+        controller.deleteTelemetryConfig(vin, mockUser)
+      ).rejects.toThrow('Error deleting telemetry configuration');
     });
   });
 

--- a/apps/api/src/app/telemetry/telemetry-config.controller.ts
+++ b/apps/api/src/app/telemetry/telemetry-config.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadGatewayException,
   Controller,
   Post,
   Get,
@@ -48,7 +49,7 @@ export class TelemetryConfigController {
       userId
     );
     if (!result) {
-      return { message: `Configuration failed for VIN: ${vin}` };
+      throw new BadGatewayException(`Configuration failed for VIN: ${vin}`);
     }
 
     if (result.skippedVehicle) {
@@ -88,6 +89,15 @@ export class TelemetryConfigController {
     this.logger.log(
       `🗑️ Deleting telemetry configuration for VIN: ${vin} (user: ${userId})`
     );
-    return await this.telemetryConfigService.deleteTelemetryConfig(vin, userId);
+    const result = await this.telemetryConfigService.deleteTelemetryConfig(
+      vin,
+      userId
+    );
+
+    if (!result.success) {
+      throw new BadGatewayException(result.message);
+    }
+
+    return result;
   }
 }

--- a/apps/webapp/src/components/VehicleCard.test.tsx
+++ b/apps/webapp/src/components/VehicleCard.test.tsx
@@ -1,0 +1,144 @@
+import { act, render, screen, fireEvent } from '@testing-library/react';
+import VehicleCard from './VehicleCard';
+import { Vehicle, VehicleActionOutcome } from '../features/vehicles/domain/entities';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('The VehicleCard component', () => {
+  const fakeVehicle: Vehicle = {
+    id: '1',
+    vin: 'VIN123',
+    display_name: 'My Tesla',
+    sentry_mode_monitoring_enabled: false,
+    break_in_monitoring_enabled: false,
+    created_at: '2026-01-01',
+    updated_at: '2026-01-01',
+  };
+
+  const renderCard = (
+    vehicle: Vehicle,
+    handlers: {
+      onToggleBreakInMonitoring?: jest.Mock;
+      onDeleteTelemetry?: jest.Mock;
+    } = {}
+  ) =>
+    render(
+      <VehicleCard
+        vehicle={vehicle}
+        onPairVirtualKey={jest.fn()}
+        onToggleTelemetry={jest.fn().mockResolvedValue({ success: true })}
+        onToggleBreakInMonitoring={
+          handlers.onToggleBreakInMonitoring ?? jest.fn().mockResolvedValue({ success: true })
+        }
+        onUpdateBreakInOffensive={jest.fn().mockResolvedValue({ success: true })}
+        onDeleteTelemetry={handlers.onDeleteTelemetry ?? jest.fn().mockResolvedValue({ success: true })}
+      />
+    );
+
+  const clickAndSettle = async (title: string): Promise<void> => {
+    await act(async () => {
+      fireEvent.click(screen.getByTitle(title));
+    });
+  };
+
+  describe('The break-in monitoring toggle', () => {
+    describe('When the toggle fails with a server message', () => {
+      const expectedMessage = 'Failed to push telemetry configuration to Tesla';
+
+      beforeEach(async () => {
+        const outcome: VehicleActionOutcome = { success: false, message: expectedMessage };
+        renderCard(fakeVehicle, {
+          onToggleBreakInMonitoring: jest.fn().mockResolvedValue(outcome),
+        });
+
+        await clickAndSettle('Enable Break-in');
+      });
+
+      it('should display the server message', () => {
+        expect(screen.getByText(expectedMessage)).toBeInTheDocument();
+      });
+    });
+
+    describe('When the toggle fails without a server message', () => {
+      beforeEach(async () => {
+        const outcome: VehicleActionOutcome = { success: false };
+        renderCard(fakeVehicle, {
+          onToggleBreakInMonitoring: jest.fn().mockResolvedValue(outcome),
+        });
+
+        await clickAndSettle('Enable Break-in');
+      });
+
+      it('should display the fallback message', () => {
+        expect(screen.getByText('Failed to update Break-in monitoring')).toBeInTheDocument();
+      });
+    });
+
+    describe('When the toggle succeeds', () => {
+      let onToggleBreakInMonitoring: jest.Mock;
+
+      beforeEach(async () => {
+        onToggleBreakInMonitoring = jest.fn().mockResolvedValue({ success: true });
+        renderCard(fakeVehicle, { onToggleBreakInMonitoring });
+
+        await clickAndSettle('Enable Break-in');
+      });
+
+      it('should request the toggle', () => {
+        expect(onToggleBreakInMonitoring).toHaveBeenCalledWith(fakeVehicle.vin, true);
+      });
+
+      it('should not display any error', () => {
+        expect(screen.queryByText('Failed to update Break-in monitoring')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('The disable telemetry button', () => {
+    const monitoredVehicle: Vehicle = { ...fakeVehicle, sentry_mode_monitoring_enabled: true };
+
+    beforeEach(() => {
+      window.confirm = jest.fn().mockReturnValue(true);
+    });
+
+    describe('When the deletion fails with a server message', () => {
+      const expectedMessage = 'Error deleting telemetry configuration';
+
+      beforeEach(async () => {
+        const outcome: VehicleActionOutcome = { success: false, message: expectedMessage };
+        renderCard(monitoredVehicle, {
+          onDeleteTelemetry: jest.fn().mockResolvedValue(outcome),
+        });
+
+        await clickAndSettle('Disable Telemetry');
+      });
+
+      it('should display the server message', () => {
+        expect(screen.getByText(expectedMessage)).toBeInTheDocument();
+      });
+    });
+
+    describe('When the deletion succeeds', () => {
+      let onDeleteTelemetry: jest.Mock;
+
+      beforeEach(async () => {
+        onDeleteTelemetry = jest.fn().mockResolvedValue({ success: true });
+        renderCard(monitoredVehicle, { onDeleteTelemetry });
+
+        await clickAndSettle('Disable Telemetry');
+      });
+
+      it('should request the deletion', () => {
+        expect(onDeleteTelemetry).toHaveBeenCalledWith(monitoredVehicle.vin);
+      });
+
+      it('should not display any error', () => {
+        expect(screen.queryByText('Failed to disable telemetry')).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/apps/webapp/src/components/VehicleCard.tsx
+++ b/apps/webapp/src/components/VehicleCard.tsx
@@ -200,11 +200,15 @@ export default function VehicleCard({
 
     setIsDeleting(true);
     setInlineError(null);
-    const result = await onDeleteTelemetry(vehicle.vin);
-    if (!result.success) {
-      setInlineError(result.message || t('Failed to disable telemetry'));
+    
+    try {
+      const result = await onDeleteTelemetry(vehicle.vin);
+      if (!result.success) {
+        setInlineError(result.message || t('Failed to disable telemetry'));
+      }
+    } finally {
+      setIsDeleting(false);
     }
-    setIsDeleting(false);
   };
 
   const handleUpdateBreakInOffensive = async (newResponse: string) => {

--- a/apps/webapp/src/components/VehicleCard.tsx
+++ b/apps/webapp/src/components/VehicleCard.tsx
@@ -2,7 +2,11 @@
 
 import { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { type Vehicle } from '../features/vehicles/domain/entities';
+import {
+  type ConfigureTelemetryOutcome,
+  type Vehicle,
+  type VehicleActionOutcome,
+} from '../features/vehicles/domain/entities';
 import Spinner from './Spinner';
 import RequireVehicleCommands from './RequireVehicleCommands';
 import VinMask from './VinMask';
@@ -183,8 +187,8 @@ export default function VehicleCard({
     setInlineError(null);
     const newStatus = !vehicle.break_in_monitoring_enabled;
     const result = await onToggleBreakInMonitoring(vehicle.vin, newStatus);
-    if (!result) {
-      setInlineError(t('Failed to update Break-in monitoring'));
+    if (!result.success) {
+      setInlineError(result.message || t('Failed to update Break-in monitoring'));
     }
     setIsConfiguringBreakIn(false);
   };
@@ -195,19 +199,20 @@ export default function VehicleCard({
     }
 
     setIsDeleting(true);
-    try {
-      await onDeleteTelemetry(vehicle.vin);
-    } finally {
-      setIsDeleting(false);
+    setInlineError(null);
+    const result = await onDeleteTelemetry(vehicle.vin);
+    if (!result.success) {
+      setInlineError(result.message || t('Failed to disable telemetry'));
     }
+    setIsDeleting(false);
   };
 
   const handleUpdateBreakInOffensive = async (newResponse: string) => {
     setIsUpdatingBreakInOffensive(true);
     setInlineError(null);
     const result = await onUpdateBreakInOffensive(vehicle.vin, newResponse);
-    if (!result) {
-      setInlineError(t('Failed to update offensive response'));
+    if (!result.success) {
+      setInlineError(result.message || t('Failed to update offensive response'));
     }
     setIsUpdatingBreakInOffensive(false);
   };
@@ -377,14 +382,8 @@ export default function VehicleCard({
 interface VehicleCardProps {
   vehicle: Vehicle;
   onPairVirtualKey: () => void;
-  onToggleTelemetry: (
-    vin: string
-  ) => Promise<{
-    success: boolean;
-    message?: string;
-    skippedVehicle?: { vin: string; reason: string; details?: string } | null;
-  }>;
-  onToggleBreakInMonitoring: (vin: string, enable: boolean) => Promise<boolean>;
-  onUpdateBreakInOffensive: (vin: string, breakInResponse: string) => Promise<boolean>;
-  onDeleteTelemetry: (vin: string) => Promise<boolean>;
+  onToggleTelemetry: (vin: string) => Promise<ConfigureTelemetryOutcome>;
+  onToggleBreakInMonitoring: (vin: string, enable: boolean) => Promise<VehicleActionOutcome>;
+  onUpdateBreakInOffensive: (vin: string, breakInResponse: string) => Promise<VehicleActionOutcome>;
+  onDeleteTelemetry: (vin: string) => Promise<VehicleActionOutcome>;
 }

--- a/apps/webapp/src/features/vehicles/domain/entities.ts
+++ b/apps/webapp/src/features/vehicles/domain/entities.ts
@@ -20,3 +20,18 @@ export interface GenericActionResponse {
   success: boolean;
   message: string;
 }
+
+export interface SkippedVehicle {
+  vin: string;
+  reason: string;
+  details?: string;
+}
+
+export interface VehicleActionOutcome {
+  success: boolean;
+  message?: string;
+}
+
+export interface ConfigureTelemetryOutcome extends VehicleActionOutcome {
+  skippedVehicle?: SkippedVehicle | null;
+}

--- a/apps/webapp/src/features/vehicles/presentation/containers/VehiclesContainer.test.tsx
+++ b/apps/webapp/src/features/vehicles/presentation/containers/VehiclesContainer.test.tsx
@@ -14,6 +14,12 @@ jest.mock('../views/VehiclesView', () => ({
   },
 }));
 
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
 let capturedProps: VehiclesViewProps;
 
 describe('The VehiclesContainer component', () => {
@@ -32,17 +38,33 @@ describe('The VehiclesContainer component', () => {
   };
 
   describe('When toggling break-in monitoring fails', () => {
-    const expectedMessage = 'Failed to push telemetry configuration to Tesla';
-    let outcome: { success: boolean; message?: string };
+    describe('When the error has a message', () => {
+      const expectedMessage = 'Failed to push telemetry configuration to Tesla';
+      let outcome: { success: boolean; message?: string };
 
-    beforeEach(async () => {
-      renderContainer(jest.fn().mockRejectedValue(new Error(expectedMessage)));
+      beforeEach(async () => {
+        renderContainer(jest.fn().mockRejectedValue(new Error(expectedMessage)));
 
-      outcome = await capturedProps.onToggleBreakInMonitoring(fakeVin, true);
+        outcome = await capturedProps.onToggleBreakInMonitoring(fakeVin, true);
+      });
+
+      it('should resolve with the failure message instead of rejecting', () => {
+        expect(outcome).toEqual({ success: false, message: expectedMessage });
+      });
     });
 
-    it('should resolve with the failure message instead of rejecting', () => {
-      expect(outcome).toEqual({ success: false, message: expectedMessage });
+    describe('When the error has no message', () => {
+      let outcome: { success: boolean; message?: string };
+
+      beforeEach(async () => {
+        renderContainer(jest.fn().mockRejectedValue('something unexpected'));
+
+        outcome = await capturedProps.onToggleBreakInMonitoring(fakeVin, true);
+      });
+
+      it('should resolve with the i18n fallback message', () => {
+        expect(outcome).toEqual({ success: false, message: 'Failed to update Break-in monitoring' });
+      });
     });
   });
 

--- a/apps/webapp/src/features/vehicles/presentation/containers/VehiclesContainer.test.tsx
+++ b/apps/webapp/src/features/vehicles/presentation/containers/VehiclesContainer.test.tsx
@@ -1,0 +1,77 @@
+import { render } from '@testing-library/react';
+import { VehiclesContainer } from './VehiclesContainer';
+import { useVehiclesQuery } from '../../di';
+import { VehiclesViewProps } from '../views/VehiclesView';
+
+jest.mock('../../di', () => ({
+  useVehiclesQuery: jest.fn(),
+}));
+
+jest.mock('../views/VehiclesView', () => ({
+  VehiclesView: (props: VehiclesViewProps) => {
+    capturedProps = props;
+    return null;
+  },
+}));
+
+let capturedProps: VehiclesViewProps;
+
+describe('The VehiclesContainer component', () => {
+  const fakeVin = 'VIN123';
+
+  const renderContainer = (mutateAsync: jest.Mock) => {
+    (useVehiclesQuery as jest.Mock).mockReturnValue({
+      query: { data: [], isLoading: false, isFetching: false, error: null, refetch: jest.fn() },
+      configureTelemetryMutation: { mutateAsync: jest.fn() },
+      deleteTelemetryMutation: { mutateAsync },
+      toggleBreakInMutation: { mutateAsync },
+      updateOffensiveResponseMutation: { mutateAsync },
+    });
+
+    render(<VehiclesContainer />);
+  };
+
+  describe('When toggling break-in monitoring fails', () => {
+    const expectedMessage = 'Failed to push telemetry configuration to Tesla';
+    let outcome: { success: boolean; message?: string };
+
+    beforeEach(async () => {
+      renderContainer(jest.fn().mockRejectedValue(new Error(expectedMessage)));
+
+      outcome = await capturedProps.onToggleBreakInMonitoring(fakeVin, true);
+    });
+
+    it('should resolve with the failure message instead of rejecting', () => {
+      expect(outcome).toEqual({ success: false, message: expectedMessage });
+    });
+  });
+
+  describe('When deleting telemetry fails', () => {
+    const expectedMessage = 'Error deleting telemetry configuration';
+    let outcome: { success: boolean; message?: string };
+
+    beforeEach(async () => {
+      renderContainer(jest.fn().mockRejectedValue(new Error(expectedMessage)));
+
+      outcome = await capturedProps.onDeleteTelemetry(fakeVin);
+    });
+
+    it('should resolve with the failure message instead of rejecting', () => {
+      expect(outcome).toEqual({ success: false, message: expectedMessage });
+    });
+  });
+
+  describe('When toggling break-in monitoring succeeds', () => {
+    let outcome: { success: boolean; message?: string };
+
+    beforeEach(async () => {
+      renderContainer(jest.fn().mockResolvedValue(true));
+
+      outcome = await capturedProps.onToggleBreakInMonitoring(fakeVin, true);
+    });
+
+    it('should resolve with a successful outcome', () => {
+      expect(outcome).toEqual({ success: true });
+    });
+  });
+});

--- a/apps/webapp/src/features/vehicles/presentation/containers/VehiclesContainer.tsx
+++ b/apps/webapp/src/features/vehicles/presentation/containers/VehiclesContainer.tsx
@@ -1,5 +1,20 @@
 import { VehiclesView } from '../views/VehiclesView';
 import { useVehiclesQuery } from '../../../vehicles/di';
+import { VehicleActionOutcome } from '../../domain/entities';
+
+const resolveActionOutcome = async (
+  action: Promise<unknown>
+): Promise<VehicleActionOutcome> => {
+  try {
+    await action;
+    return { success: true };
+  } catch (error: unknown) {
+    return {
+      success: false,
+      message: error instanceof Error ? error.message : undefined,
+    };
+  }
+};
 
 export function VehiclesContainer() {
   const {
@@ -19,16 +34,13 @@ export function VehiclesContainer() {
       error={error?.message || null}
       onRefresh={refetch}
       onConfigureTelemetry={async (vin) => configureTelemetryMutation.mutateAsync(vin)}
-      onDeleteTelemetry={async (vin) => deleteTelemetryMutation.mutateAsync(vin)}
-      onToggleBreakInMonitoring={async (vin, enable) => toggleBreakInMutation.mutateAsync({ vin, enable })}
-      onUpdateBreakInOffensive={async (vin, breakInResponse) => {
-        try {
-          await updateOffensiveResponseMutation.mutateAsync({ vin, breakInResponse });
-          return true;
-        } catch {
-          return false;
-        }
-      }}
+      onDeleteTelemetry={async (vin) => resolveActionOutcome(deleteTelemetryMutation.mutateAsync(vin))}
+      onToggleBreakInMonitoring={async (vin, enable) =>
+        resolveActionOutcome(toggleBreakInMutation.mutateAsync({ vin, enable }))
+      }
+      onUpdateBreakInOffensive={async (vin, breakInResponse) =>
+        resolveActionOutcome(updateOffensiveResponseMutation.mutateAsync({ vin, breakInResponse }))
+      }
     />
   );
 }

--- a/apps/webapp/src/features/vehicles/presentation/containers/VehiclesContainer.tsx
+++ b/apps/webapp/src/features/vehicles/presentation/containers/VehiclesContainer.tsx
@@ -1,9 +1,11 @@
 import { VehiclesView } from '../views/VehiclesView';
 import { useVehiclesQuery } from '../../../vehicles/di';
 import { VehicleActionOutcome } from '../../domain/entities';
+import { useTranslation } from 'react-i18next';
 
 const resolveActionOutcome = async (
-  action: Promise<unknown>
+  action: Promise<unknown>,
+  fallback: string
 ): Promise<VehicleActionOutcome> => {
   try {
     await action;
@@ -11,7 +13,7 @@ const resolveActionOutcome = async (
   } catch (error: unknown) {
     return {
       success: false,
-      message: error instanceof Error ? error.message : undefined,
+      message: error instanceof Error && error.message ? error.message : fallback,
     };
   }
 };
@@ -24,6 +26,7 @@ export function VehiclesContainer() {
     toggleBreakInMutation,
     updateOffensiveResponseMutation,
   } = useVehiclesQuery();
+  const { t } = useTranslation();
 
   const { data: vehicles = [], isLoading, isFetching, error, refetch } = query;
 
@@ -34,12 +37,23 @@ export function VehiclesContainer() {
       error={error?.message || null}
       onRefresh={refetch}
       onConfigureTelemetry={async (vin) => configureTelemetryMutation.mutateAsync(vin)}
-      onDeleteTelemetry={async (vin) => resolveActionOutcome(deleteTelemetryMutation.mutateAsync(vin))}
+      onDeleteTelemetry={async (vin) =>
+        resolveActionOutcome(
+          deleteTelemetryMutation.mutateAsync(vin),
+          t('Failed to disable telemetry')
+        )
+      }
       onToggleBreakInMonitoring={async (vin, enable) =>
-        resolveActionOutcome(toggleBreakInMutation.mutateAsync({ vin, enable }))
+        resolveActionOutcome(
+          toggleBreakInMutation.mutateAsync({ vin, enable }),
+          t('Failed to update Break-in monitoring')
+        )
       }
       onUpdateBreakInOffensive={async (vin, breakInResponse) =>
-        resolveActionOutcome(updateOffensiveResponseMutation.mutateAsync({ vin, breakInResponse }))
+        resolveActionOutcome(
+          updateOffensiveResponseMutation.mutateAsync({ vin, breakInResponse }),
+          t('Failed to update offensive response')
+        )
       }
     />
   );

--- a/apps/webapp/src/features/vehicles/presentation/queries/use-vehicles-query.test.tsx
+++ b/apps/webapp/src/features/vehicles/presentation/queries/use-vehicles-query.test.tsx
@@ -140,6 +140,22 @@ describe('The useVehiclesQuery() hook', () => {
         });
       });
     });
+
+    describe('When the API rejects the request', () => {
+      it('should resolve with the API error message instead of throwing', async () => {
+        const expectedMessage = 'Configuration failed for VIN: VIN123';
+        mockConfigureTelemetryUseCase.execute.mockRejectedValue(new Error(expectedMessage));
+
+        const { result } = renderHook(() => useVehiclesQuery(), { wrapper });
+        const response = await result.current.configureTelemetryMutation.mutateAsync('VIN123');
+
+        expect(response).toEqual({
+          success: false,
+          message: expectedMessage,
+          skippedVehicle: null,
+        });
+      });
+    });
   });
 
   describe('When deleting telemetry config', () => {

--- a/apps/webapp/src/features/vehicles/presentation/queries/use-vehicles-query.ts
+++ b/apps/webapp/src/features/vehicles/presentation/queries/use-vehicles-query.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Vehicle } from '../../domain/entities';
+import { ConfigureTelemetryOutcome, TelemetryConfigResult, Vehicle } from '../../domain/entities';
 import { hasToken } from '../../../../core/api/token-manager';
 import {
   GetVehiclesRequirements,
@@ -17,6 +17,27 @@ export interface VehiclesQueryDependencies {
   updateOffensiveResponseUseCase: UpdateOffensiveResponseRequirements;
 }
 
+const resolveErrorMessage = (error: unknown, fallback: string): string =>
+  error instanceof Error && error.message ? error.message : fallback;
+
+const resolveConfigureTelemetryOutcome = (
+  response: TelemetryConfigResult
+): ConfigureTelemetryOutcome => {
+  const skippedVehicle = response?.result?.skippedVehicle ?? null;
+
+  if (response?.result?.success === true && !skippedVehicle) {
+    return { success: true };
+  }
+
+  const message =
+    response?.message ||
+    (skippedVehicle
+      ? 'Telemetry configuration skipped for this vehicle'
+      : 'Failed to configure telemetry');
+
+  return { success: false, message, skippedVehicle };
+};
+
 export const createUseVehiclesQuery = (deps: VehiclesQueryDependencies) => () => {
   const queryClient = useQueryClient();
 
@@ -31,22 +52,18 @@ export const createUseVehiclesQuery = (deps: VehiclesQueryDependencies) => () =>
   });
 
   const configureTelemetryMutation = useMutation({
-    mutationFn: async (vin: string) => {
-      const response = await deps.configureTelemetryUseCase.execute(vin);
-      const skippedVehicle = response?.result?.skippedVehicle ?? null;
-      const success = response?.result?.success === true && !skippedVehicle;
-
-      if (success) {
-        return { success: true };
+    mutationFn: async (vin: string): Promise<ConfigureTelemetryOutcome> => {
+      try {
+        return resolveConfigureTelemetryOutcome(
+          await deps.configureTelemetryUseCase.execute(vin)
+        );
+      } catch (error: unknown) {
+        return {
+          success: false,
+          message: resolveErrorMessage(error, 'Failed to configure telemetry'),
+          skippedVehicle: null,
+        };
       }
-
-      const message =
-        response?.message ||
-        (skippedVehicle
-          ? 'Telemetry configuration skipped for this vehicle'
-          : 'Failed to configure telemetry');
-
-      return { success: false, message, skippedVehicle };
     },
     onSuccess: (data) => {
       if (data.success) {

--- a/apps/webapp/src/features/vehicles/presentation/views/VehiclesView.tsx
+++ b/apps/webapp/src/features/vehicles/presentation/views/VehiclesView.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Vehicle } from '../../domain/entities';
+import { ConfigureTelemetryOutcome, Vehicle, VehicleActionOutcome } from '../../domain/entities';
 import VehicleCard from '../../../../components/VehicleCard';
 import { resolveVirtualKeyUrl } from '../../../../core/api/api-client';
 
@@ -8,14 +8,10 @@ export interface VehiclesViewProps {
   isLoading: boolean;
   error: string | null;
   onRefresh: () => void;
-  onConfigureTelemetry: (vin: string) => Promise<{
-    success: boolean;
-    message?: string;
-    skippedVehicle?: { vin: string; reason: string; details?: string } | null;
-  }>;
-  onDeleteTelemetry: (vin: string) => Promise<boolean>;
-  onToggleBreakInMonitoring: (vin: string, enable: boolean) => Promise<boolean>;
-  onUpdateBreakInOffensive: (vin: string, breakInResponse: string) => Promise<boolean>;
+  onConfigureTelemetry: (vin: string) => Promise<ConfigureTelemetryOutcome>;
+  onDeleteTelemetry: (vin: string) => Promise<VehicleActionOutcome>;
+  onToggleBreakInMonitoring: (vin: string, enable: boolean) => Promise<VehicleActionOutcome>;
+  onUpdateBreakInOffensive: (vin: string, breakInResponse: string) => Promise<VehicleActionOutcome>;
 }
 
 export function VehiclesView({

--- a/apps/webapp/src/locales/en/common.json
+++ b/apps/webapp/src/locales/en/common.json
@@ -36,6 +36,7 @@
   "Failed to initiate login": "Failed to initiate login",
   "Failed to configure telemetry": "Failed to configure telemetry",
   "Failed to enable telemetry": "Failed to enable telemetry",
+  "Failed to disable telemetry": "Failed to disable telemetry",
   "Virtual key not added to the vehicle": "Virtual key not added to the vehicle",
   "Unsupported hardware (pre-2018 Model S/X)": "Unsupported hardware (pre-2018 Model S/X)",
   "Unsupported firmware version for telemetry": "Unsupported firmware version for telemetry",

--- a/apps/webapp/src/locales/fr/common.json
+++ b/apps/webapp/src/locales/fr/common.json
@@ -351,7 +351,7 @@
   "Break-in Monitoring": "Surveillance d'effraction",
   "Enable Break-in": "Activer surveillance d'effraction",
   "Disable Break-in": "Désactiver surveillance d'effraction",
-  "Failed to update Break-in monitoring": "Échec de la mise à la surveillance d'effraction",
+  "Failed to update Break-in monitoring": "Échec de la mise à jour de la surveillance d'effraction",
   "Offensive Response": "Réponse offensive",
   "offensiveResponseOn": "Klaxon activé",
   "offensiveResponseOff": "Klaxon désactivé",

--- a/apps/webapp/src/locales/fr/common.json
+++ b/apps/webapp/src/locales/fr/common.json
@@ -36,6 +36,7 @@
   "Failed to initiate login": "Échec de l'initialisation de la connexion",
   "Failed to configure telemetry": "Échec de la configuration de la télémétrie",
   "Failed to enable telemetry": "Échec de l'activation de la télémétrie",
+  "Failed to disable telemetry": "Échec de la désactivation de la télémétrie",
   "Virtual key not added to the vehicle": "Clé virtuelle non ajoutée au véhicule",
   "Unsupported hardware (pre-2018 Model S/X)": "Matériel non supporté (Model S/X avant 2018)",
   "Unsupported firmware version for telemetry": "Version logicielle non supportée pour la télémétrie",


### PR DESCRIPTION
Resolves #214.

## Problem

When the Web App enabled or disabled break-in monitoring and the backend failed to push the configuration to Tesla (vehicle asleep, timeout, revoked token), the API answered:

```
HTTP 201 Created
{ "success": false, "message": "Failed to push telemetry configuration to Tesla" }
```

A `2xx` status means "this worked", so `ApiClient` handed the body back as a success. The React Query mutation then compensated by throwing manually:

```ts
if (!result.success) throw new Error(result.message);
```

That throw is correct React Query practice — but nothing downstream caught it. `VehiclesContainer` passed `mutateAsync` straight through:

```tsx
onToggleBreakInMonitoring={async (vin, enable) => toggleBreakInMutation.mutateAsync({ vin, enable })}
```

and `VehicleCard` awaited it without a `try/catch`. The rejection escaped into the void, and since Rollbar is configured with `captureUnhandledRejections: true`, every failed toggle was reported as an application crash (~21 occurrences over 28 days).

Note the prop was already typed `Promise<boolean>` while the implementation could reject — the contract was lying, which is what let the bug through code review.

The onboarding flow was unaffected: `use-telemetry-activation.ts` already wraps these calls in `try/catch`. All reported occurrences came from the dashboard.

## Root cause

Two independent defects that combined:

1. **Backend** — a failed operation returned a success status code.
2. **Frontend** — the container let a rejecting promise reach a component that treated it as a resolved boolean.

Fixing only the status code would not have been enough: a `502` makes `ApiClient` throw, which would have produced the exact same unhandled rejection. Both halves needed addressing.

## Changes

### Backend

`BreakInMonitoringConfigService` no longer swallows failures into a `{ success: false }` payload. It throws real HTTP exceptions:

| Situation | Before | After |
|---|---|---|
| Vehicle not found | 201 + `success:false` | **404** `NotFoundException` |
| Tesla push failed | 201 + `success:false` | **502** `BadGatewayException` |
| Unexpected error | 201 + `success:false` | **500** `InternalServerErrorException` |
| Success | 201 | **200** |

The same defect existed on two sibling endpoints, fixed here too:
- `POST /telemetry-config/configure/:vin` returned 201 on hard failure → now 502. The *skipped vehicle* case stays `2xx`, since it is a legitimate business outcome the UI renders with a specific reason (missing key, unsupported hardware…), not an error.
- `DELETE /telemetry-config/:vin` returned 200 with `success:false` → now 502.

Toggles return **200** rather than the NestJS default 201: they flip a boolean on an existing vehicle, they do not create a resource, and they are idempotent.

The service was also split into single-purpose private methods to satisfy the repository's 10-line method guideline.

### Frontend

`VehiclesContainer` becomes the boundary that adapts rejections to the presentational contract:

```ts
const resolveActionOutcome = async (action: Promise<unknown>): Promise<VehicleActionOutcome> => {
  try {
    await action;
    return { success: true };
  } catch (error: unknown) {
    return { success: false, message: error instanceof Error ? error.message : undefined };
  }
};
```

Props move from `Promise<boolean>` to `Promise<VehicleActionOutcome>`, so the contract is now honest **and** the real server message reaches the user instead of a generic fallback.

`configureTelemetryMutation` catches API errors and keeps returning its result object, preserving the existing skipped-vehicle UX now that the endpoint can answer 502.

### Note on the "Toast" suggestion

The issue asks for a Toast notification. The Web App has no toast system — the established pattern is inline errors (`inlineError` in `VehicleCard`, an error map in onboarding, a banner in `VehiclesView`). This PR surfaces the failure through the existing inline mechanism. Introducing a fourth notification pattern would hurt consistency; unifying them is worth its own ticket.

## Mobile

Unaffected. Every mobile mutation already declares `onError`, so the new status codes surface as user feedback through the existing path. `ApiClient` extracts the `message` field from the error body.

## Tests

- `break-in-monitoring-config.service.spec.ts` — the three exception paths
- `telemetry-config.controller.spec.ts` — configure and delete failures
- `use-vehicles-query.test.tsx` — a rejecting API resolves into an outcome rather than throwing
- `VehiclesContainer.test.tsx` (new) — locks the regression: a rejected mutation must not escape the container
- `VehicleCard.test.tsx` (new) — the component had **no test file at all**; covers server message, fallback message, and success for both the break-in toggle and the disable button

Verified: `lint` 0 errors, 18 suites / 137 tests green on api + webapp, `typecheck mobile` passes.

### Known coverage gap

No test asserts the HTTP status codes themselves. Controller specs call methods directly and never cross the HTTP layer, so they prove the right exception class is thrown — which determines the status — but no test observes an actual `502` or `200`. There is no supertest/e2e harness in the repo; adding one is out of scope here.
