### PR TITLE
fix(api): handle blocked-bot errors on every Telegram send path

### DIFF
--- a/apps/api/src/app/telegram/telegram.controller.spec.ts
+++ b/apps/api/src/app/telegram/telegram.controller.spec.ts
@@ -1,0 +1,182 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { mock, MockProxy } from 'jest-mock-extended';
+import { Repository } from 'typeorm';
+import { TelegramController } from './telegram.controller';
+import { TelegramBotService } from './telegram-bot.service';
+import { TelegramContextService } from './telegram-context.service';
+import {
+  ITelegramFailureHandler,
+  telegramFailureHandler,
+} from './interfaces/telegram-failure-handler.interface';
+import { TelegramConfig } from '../../entities/telegram-config.entity';
+import { User } from '../../entities/user.entity';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { ConsentGuard } from '../../common/guards/consent.guard';
+
+describe('The TelegramController class', () => {
+  const fakeChatId = '123456789';
+  const fakeUser = { userId: 'user-1', email: 'test@example.com' } as User;
+  const blockedBotError = new Error('403: Forbidden: bot was blocked by the user');
+
+  let controller: TelegramController;
+  let mockTelegramBotService: MockProxy<TelegramBotService>;
+  let mockTelegramContextService: MockProxy<TelegramContextService>;
+  let mockFailureHandler: MockProxy<ITelegramFailureHandler>;
+  let mockTelegramConfigRepository: MockProxy<Repository<TelegramConfig>>;
+
+  beforeEach(async () => {
+    mockTelegramBotService = mock<TelegramBotService>();
+    mockTelegramContextService = mock<TelegramContextService>();
+    mockFailureHandler = mock<ITelegramFailureHandler>();
+    mockTelegramConfigRepository = mock<Repository<TelegramConfig>>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TelegramController],
+      providers: [
+        { provide: getRepositoryToken(TelegramConfig), useValue: mockTelegramConfigRepository },
+        { provide: TelegramBotService, useValue: mockTelegramBotService },
+        { provide: TelegramContextService, useValue: mockTelegramContextService },
+        { provide: telegramFailureHandler, useValue: mockFailureHandler },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: jest.fn().mockReturnValue(true) })
+      .overrideGuard(ConsentGuard)
+      .useValue({ canActivate: jest.fn().mockReturnValue(true) })
+      .compile();
+
+    controller = module.get<TelegramController>(TelegramController);
+    mockTelegramContextService.getChatIdFromUserId.mockResolvedValue(fakeChatId);
+  });
+
+  describe('The sendTestMessage() method', () => {
+    describe('When the account is not linked', () => {
+      let result: { success: boolean; message: string };
+
+      beforeEach(async () => {
+        mockTelegramContextService.getChatIdFromUserId.mockResolvedValue(null);
+
+        result = await controller.sendTestMessage(fakeUser);
+      });
+
+      it('should report a failure', () => {
+        expect(result.success).toBe(false);
+      });
+
+      it('should not attempt to send a message', () => {
+        expect(mockTelegramBotService.sendMessage).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('When the message is sent', () => {
+      let result: { success: boolean; message: string };
+
+      beforeEach(async () => {
+        mockTelegramBotService.sendMessage.mockResolvedValue(true);
+
+        result = await controller.sendTestMessage(fakeUser);
+      });
+
+      it('should report a success', () => {
+        expect(result).toEqual({ success: true, message: 'Message sent successfully' });
+      });
+
+      it('should not invoke the failure handler', () => {
+        expect(mockFailureHandler.handleFailure).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('When the user has blocked the bot', () => {
+      let result: { success: boolean; message: string };
+
+      beforeEach(async () => {
+        mockTelegramBotService.sendMessage.mockRejectedValue(blockedBotError);
+        mockFailureHandler.canHandle.mockReturnValue(true);
+        mockFailureHandler.handleFailure.mockResolvedValue(undefined);
+
+        result = await controller.sendTestMessage(fakeUser);
+      });
+
+      it('should not let the error escape the controller', () => {
+        expect(result.success).toBe(false);
+      });
+
+      it('should delegate to the failure handler', () => {
+        expect(mockFailureHandler.handleFailure).toHaveBeenCalledWith(
+          blockedBotError,
+          fakeUser.userId
+        );
+      });
+    });
+
+    describe('When disabling Telegram also fails', () => {
+      let result: { success: boolean; message: string };
+
+      beforeEach(async () => {
+        mockTelegramBotService.sendMessage.mockRejectedValue(blockedBotError);
+        mockFailureHandler.canHandle.mockReturnValue(true);
+        mockFailureHandler.handleFailure.mockRejectedValue(new Error('Database connection failed'));
+
+        result = await controller.sendTestMessage(fakeUser);
+      });
+
+      it('should still report a failure instead of throwing', () => {
+        expect(result.success).toBe(false);
+      });
+    });
+
+    describe('When the rejection is not an Error instance', () => {
+      let result: { success: boolean; message: string };
+      let errorSpy: jest.SpyInstance;
+
+      beforeEach(async () => {
+        errorSpy = jest.spyOn(controller['logger'], 'error').mockImplementation();
+        mockTelegramBotService.sendMessage.mockRejectedValue('403: Forbidden');
+
+        result = await controller.sendTestMessage(fakeUser);
+      });
+
+      afterEach(() => {
+        errorSpy.mockRestore();
+      });
+
+      it('should report a failure instead of throwing', () => {
+        expect(result.success).toBe(false);
+      });
+
+      it('should not ask the failure handler to inspect it', () => {
+        expect(mockFailureHandler.canHandle).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('When the failure is unrelated to a blocked bot', () => {
+      let result: { success: boolean; message: string };
+      let errorSpy: jest.SpyInstance;
+
+      beforeEach(async () => {
+        errorSpy = jest.spyOn(controller['logger'], 'error').mockImplementation();
+        mockTelegramBotService.sendMessage.mockRejectedValue(new Error('network timeout'));
+        mockFailureHandler.canHandle.mockReturnValue(false);
+
+        result = await controller.sendTestMessage(fakeUser);
+      });
+
+      afterEach(() => {
+        errorSpy.mockRestore();
+      });
+
+      it('should report a failure', () => {
+        expect(result.success).toBe(false);
+      });
+
+      it('should not disable the Telegram integration', () => {
+        expect(mockFailureHandler.handleFailure).not.toHaveBeenCalled();
+      });
+
+      it('should log the unexpected failure', () => {
+        expect(errorSpy).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/apps/api/src/app/telegram/telegram.controller.ts
+++ b/apps/api/src/app/telegram/telegram.controller.ts
@@ -3,6 +3,7 @@ import {
   Post,
   Get,
   Delete,
+  Inject,
   Logger,
   UseGuards,
   BadRequestException,
@@ -17,6 +18,8 @@ import {
 } from '../../entities/telegram-config.entity';
 import { TelegramBotService } from './telegram-bot.service';
 import { TelegramContextService } from './telegram-context.service';
+import { telegramFailureHandler } from './interfaces/telegram-failure-handler.interface';
+import type { ITelegramFailureHandler } from './interfaces/telegram-failure-handler.interface';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { ConsentGuard } from '../../common/guards/consent.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
@@ -35,6 +38,8 @@ export class TelegramController {
     private readonly telegramConfigRepository: Repository<TelegramConfig>,
     private readonly telegramBotService: TelegramBotService,
     private readonly telegramContextService: TelegramContextService,
+    @Inject(telegramFailureHandler)
+    private readonly failureHandler: ITelegramFailureHandler,
   ) {}
 
   /**
@@ -186,7 +191,7 @@ export class TelegramController {
       return { success: false, message: 'Failed to send message. Verify that the account is linked.' };
     }
 
-    const success = await this.telegramBotService.sendMessage(chatId, message);
+    const success = await this.sendTestMessageSafely(chatId, message, userId);
 
     return {
       success,
@@ -194,5 +199,46 @@ export class TelegramController {
         ? 'Message sent successfully'
         : 'Failed to send message. Verify that the account is linked.',
     };
+  }
+
+  private async sendTestMessageSafely(
+    chatId: string,
+    message: string,
+    userId: string
+  ): Promise<boolean> {
+    try {
+      return await this.telegramBotService.sendMessage(chatId, message);
+    } catch (error: unknown) {
+      await this.handleTestMessageFailure(error, userId);
+
+      return false;
+    }
+  }
+
+  private async handleTestMessageFailure(error: unknown, userId: string): Promise<void> {
+    if (!this.isBlockedBotFailure(error)) {
+      this.logger.error(
+        `[TELEGRAM_TEST] Failed to send test message for user ${userId}:`,
+        error
+      );
+      return;
+    }
+
+    await this.disableTelegramSafely(error, userId);
+  }
+
+  private isBlockedBotFailure(error: unknown): error is Error {
+    return error instanceof Error && this.failureHandler.canHandle(error);
+  }
+
+  private async disableTelegramSafely(error: Error, userId: string): Promise<void> {
+    try {
+      await this.failureHandler.handleFailure(error, userId);
+      this.logger.log(`[TELEGRAM_FAILURE_HANDLED] Error handled for user ${userId}`);
+    } catch {
+      this.logger.warn(
+        `[TELEGRAM_TEST] Could not disable Telegram for user ${userId} after a blocked-bot error`
+      );
+    }
   }
 }

--- a/apps/api/src/app/telegram/telegram.service.spec.ts
+++ b/apps/api/src/app/telegram/telegram.service.spec.ts
@@ -196,6 +196,57 @@ describe('The TelegramService class', () => {
       });
     });
 
+    describe('When the bot UI update fails because the bot is blocked', () => {
+      const blockedBotError = new Error('403: Forbidden: bot was blocked by the user');
+
+      let result: boolean;
+
+      beforeEach(async () => {
+        mockTelegramBotUpdateService.ensureUserIsUpToDate.mockRejectedValue(blockedBotError);
+        mockTelegramFailureHandler.canHandle.mockReturnValue(true);
+        mockTelegramFailureHandler.handleFailure.mockResolvedValue(undefined);
+
+        result = await service.sendSentryAlert(fakeUserId, alertInfo, 'en');
+      });
+
+      afterEach(() => {
+        mockTelegramBotUpdateService.ensureUserIsUpToDate.mockResolvedValue(undefined);
+      });
+
+      it('should route the error to the failure handler', () => {
+        expect(mockTelegramFailureHandler.handleFailure).toHaveBeenCalledWith(
+          blockedBotError,
+          fakeUserId
+        );
+      });
+
+      it('should return false instead of throwing', () => {
+        expect(result).toBe(false);
+      });
+
+      it('should not attempt to send the alert', () => {
+        expect(mockTelegramBotService.sendMessage).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('When the rejection is not an Error instance', () => {
+      let act: () => Promise<boolean>;
+
+      beforeEach(() => {
+        mockTelegramBotService.sendMessage.mockRejectedValue('403: Forbidden');
+        act = () => service.sendSentryAlert(fakeUserId, alertInfo, 'en');
+      });
+
+      it('should propagate the original rejection unchanged', async () => {
+        await expect(act()).rejects.toBe('403: Forbidden');
+      });
+
+      it('should not ask the failure handler to inspect it', async () => {
+        await expect(act()).rejects.toBeDefined();
+        expect(mockTelegramFailureHandler.canHandle).not.toHaveBeenCalled();
+      });
+    });
+
     describe('When the failure handler cannot handle the error', () => {
       it('should rethrow the error', async () => {
         const testError = new Error('Unknown error');
@@ -275,6 +326,51 @@ describe('The TelegramService class', () => {
 
         expect(result).toBe(false);
         expect(mockRetryManager.addToRetry).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('The sendBreakInAlert() method', () => {
+    const alertInfo = { vin: 'TEST123456' };
+
+    describe('When the bot UI update fails because the bot is blocked', () => {
+      const blockedBotError = new Error('403: Forbidden: bot was blocked by the user');
+
+      let result: boolean;
+
+      beforeEach(async () => {
+        mockTelegramBotUpdateService.ensureUserIsUpToDate.mockRejectedValue(blockedBotError);
+        mockTelegramFailureHandler.canHandle.mockReturnValue(true);
+        mockTelegramFailureHandler.handleFailure.mockResolvedValue(undefined);
+
+        result = await service.sendBreakInAlert(fakeUserId, alertInfo, 'en');
+      });
+
+      afterEach(() => {
+        mockTelegramBotUpdateService.ensureUserIsUpToDate.mockResolvedValue(undefined);
+      });
+
+      it('should route the error to the failure handler', () => {
+        expect(mockTelegramFailureHandler.handleFailure).toHaveBeenCalledWith(
+          blockedBotError,
+          fakeUserId
+        );
+      });
+
+      it('should return false instead of throwing', () => {
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('When the alert is sent', () => {
+      beforeEach(() => {
+        mockTelegramBotService.sendMessage.mockResolvedValue(true);
+      });
+
+      it('should return true', async () => {
+        const result = await service.sendBreakInAlert(fakeUserId, alertInfo, 'en');
+
+        expect(result).toBe(true);
       });
     });
   });

--- a/apps/api/src/app/telegram/telegram.service.ts
+++ b/apps/api/src/app/telegram/telegram.service.ts
@@ -1,12 +1,12 @@
-import { Injectable, Logger, Inject, OnModuleDestroy } from '@nestjs/common';
+import { Inject, Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
 import { TelegramError } from 'telegraf';
 import i18n from '../../i18n';
 import { TelegramBotService } from './telegram-bot.service';
 import { TelegramMuteService } from './telegram-mute.service';
 import { TelegramContextService } from './telegram-context.service';
 import { TelegramBotUpdateService } from './telegram-bot-update.service';
-import { telegramFailureHandler } from './interfaces/telegram-failure-handler.interface';
 import type { ITelegramFailureHandler } from './interfaces/telegram-failure-handler.interface';
+import { telegramFailureHandler } from './interfaces/telegram-failure-handler.interface';
 import { telegramRetryManager } from './telegram-retry-manager.token';
 import { RetryManager } from '../shared/retry-manager.service';
 
@@ -52,21 +52,27 @@ export class TelegramService implements OnModuleDestroy {
       return false;
     }
 
-    await this.telegramBotUpdateService.ensureUserIsUpToDate(userId, chatId, userLanguage);
-
-    if (this.shouldSimulateMessage(alertInfo.vin)) {
-      return await this.simulateMessage(userId, 'alert', alertInfo.vin);
-    }
-
     const options = keyboard ? { keyboard } : undefined;
 
     try {
-      const success = await this.telegramBotService.sendMessage(chatId, message, options);
+      await this.telegramBotUpdateService.ensureUserIsUpToDate(
+        userId,
+        chatId,
+        userLanguage
+      );
 
-      return success;
+      if (this.shouldSimulateMessage(alertInfo.vin)) {
+        return await this.simulateMessage(userId, 'alert', alertInfo.vin);
+      }
+
+      return await this.telegramBotService.sendMessage(
+        chatId,
+        message,
+        options
+      );
     } catch (error) {
-      if (this.failureHandler.canHandle(error as Error)) {
-        await this.failureHandler.handleFailure(error as Error, userId);
+      if (this.isBlockedBotFailure(error)) {
+        await this.failureHandler.handleFailure(error, userId);
         this.logger.log(`[TELEGRAM_FAILURE_HANDLED] Error handled for user ${userId}`);
 
         return false;
@@ -113,21 +119,27 @@ export class TelegramService implements OnModuleDestroy {
       return false;
     }
 
-    await this.telegramBotUpdateService.ensureUserIsUpToDate(userId, chatId, userLanguage);
-
-    if (this.shouldSimulateMessage(alertInfo.vin)) {
-      return await this.simulateMessage(userId, 'alert', alertInfo.vin);
-    }
-
     const options = keyboard ? { keyboard } : undefined;
 
     try {
-      const success = await this.telegramBotService.sendMessage(chatId, message, options);
+      await this.telegramBotUpdateService.ensureUserIsUpToDate(
+        userId,
+        chatId,
+        userLanguage
+      );
 
-      return success;
+      if (this.shouldSimulateMessage(alertInfo.vin)) {
+        return await this.simulateMessage(userId, 'alert', alertInfo.vin);
+      }
+
+      return await this.telegramBotService.sendMessage(
+        chatId,
+        message,
+        options
+      );
     } catch (error) {
-      if (this.failureHandler.canHandle(error as Error)) {
-        await this.failureHandler.handleFailure(error as Error, userId);
+      if (this.isBlockedBotFailure(error)) {
+        await this.failureHandler.handleFailure(error, userId);
         this.logger.log(`[TELEGRAM_FAILURE_HANDLED] Error handled for user ${userId}`);
 
         return false;
@@ -154,6 +166,10 @@ export class TelegramService implements OnModuleDestroy {
 
   onModuleDestroy() {
     this.retryManager.stop();
+  }
+
+  private isBlockedBotFailure(error: unknown): error is Error {
+    return error instanceof Error && this.failureHandler.canHandle(error);
   }
 
   private isRetryableTelegramError(error: unknown): boolean {


### PR DESCRIPTION
Resolves #212.

## Problem

`TelegramController.sendTestMessage` called `telegramBotService.sendMessage` bare:

```ts
const success = await this.telegramBotService.sendMessage(chatId, message);
```

`TelegramService` makes the identical call but wraps it in the failure handler. The test-message route bypassed all of that, so a user who blocked the bot produced a 403 that escaped to the global `ExceptionsHandler` — and their Telegram integration was never disabled.

## Fix

The controller now injects the failure handler and reuses the exact flow from [`telegram.service.ts`](apps/api/src/app/telegram/telegram.service.ts): `canHandle` → `handleFailure` → `return false`. No new mechanism, no duplicated policy.

## The same defect existed in the alert paths

Auditing every caller of `sendMessage` turned up one more unguarded sender: [`telegram-bot-update.service.ts:30`](apps/api/src/app/telegram/telegram-bot-update.service.ts). It sends the bot-UI migration message, and it was invoked **just before** the `try` block in both `sendSentryAlert` and `sendBreakInAlert`:

```ts
await this.telegramBotUpdateService.ensureUserIsUpToDate(...);   // sends a message, outside try
...
try {
  const success = await this.telegramBotService.sendMessage(...);
} catch (error) {
  if (this.failureHandler.canHandle(...)) {                      // unreachable from the call above
```

**This one is persistent, not occasional.** `bot_ui_version` is only bumped *after* a successful send. A user who blocked the bot before receiving the migration message keeps a stale version forever, so **every** Sentry or break-in alert throws a 403 that never reaches the handler. Compared to the reported case — a manually triggered test message, 3 occurrences in 28 days — this fires on every alert.

The `try` now covers it. I moved the `try` upward rather than moving the call down past the `shouldSimulateMessage` check, so the execution order is byte-for-byte preserved and the migration still runs in simulation mode. Verified beforehand that `simulateMessage` is a sleep plus a log and never throws, so including it changes nothing.

**Side benefit:** a retryable failure from the migration (say a 429) now reaches the retry manager, where previously the whole alert was lost.

## A defect in the first version of this fix

Both files guarded on `canHandle(error as Error)`. `canHandle` reads `error.message`, so a rejection that is not an `Error` throws a `TypeError` — from *inside* the catch block:

```
TypeError: Cannot read properties of undefined (reading 'toLowerCase')
```

In the controller that escaped the request, recreating the very bug being fixed. In the service it replaced the original rejection with a misleading message, destroying the diagnostic exactly when it was needed.

A shared type guard fixes both:

```ts
private isBlockedBotFailure(error: unknown): error is Error {
  return error instanceof Error && this.failureHandler.canHandle(error);
}
```

The predicate also removes the `as Error` casts, which were what hid the problem from the compiler.

Worth noting: unit tests could not have caught this, since the specs inject a **mocked** handler whose `canHandle` returns `undefined` without throwing. It only shows against the real implementation.

## What was deliberately left asymmetric

The controller wraps `handleFailure` so that a database failure during cleanup cannot escape either — `handleFailure` rethrows on failure, per its own spec. The service does **not** get that guard: it intentionally rethrows unhandled errors (`throw error`), and its callers already sit behind `Promise.allSettled`. Swallowing there would change its contract. Aligning the two by symmetry would have been wrong.

## Tests

`telegram.controller.spec.ts` is **new** — the controller had no tests at all. `sendBreakInAlert` had none either, despite being the break-in alert path.

Covered: unlinked account, successful send, blocked bot, failure while disabling, non-`Error` rejection, and an unrelated network error. That last one asserts Telegram is **not** disabled by mistake, and `should not attempt to send the alert` asserts we do not push the alert after a failed migration — a fix that swallowed the error and carried on would otherwise pass unnoticed.

69 suites / **788 tests** green (+20 over the 768 baseline), lint unchanged at 62 warnings, `nx build api` clean.

## Note on validation

`nx test` and `nx lint` both pass on code that does not compile: Jest uses `@swc/jest`, which strips types without checking them, ESLint does not typecheck, and `typecheck api` is not CI-gated (only `mobile` is, which is a documented gotcha in this repo). `nx build api` is what catches this class of error, and it was needed here after the first version of the import.

## Not addressed

`sendSentryAlert` and `sendBreakInAlert` are near-identical across ~40 lines, which the two-occurrence edits in this PR make plain. Factoring them out is the right follow-up but would balloon the review surface of a bug fix.
