### PR TITLE
fix: override vehicle command protocol required for Model 3/Y/C

### DIFF
--- a/apps/api/src/app/telemetry/telemetry-config.service.spec.ts
+++ b/apps/api/src/app/telemetry/telemetry-config.service.spec.ts
@@ -548,6 +548,23 @@ describe('TelemetryConfigService', () => {
       );
     });
 
+    it('should force vehicle_command_protocol_required to true for Model 3/Y/Cybertruck even if fleet_status returns false', async () => {
+      const vin = 'LRWY1234567890'; // 4th char is Y
+      const mockConfig = { key_paired: false, fields: {} };
+
+      mockAccessTokenService.getAccessTokenForUserId.mockResolvedValue('user-access-token');
+      mockAxiosInstance.get.mockResolvedValueOnce({
+        data: { response: mockConfig },
+      });
+      mockAxiosInstance.post.mockResolvedValueOnce({
+        data: { response: { vehicle_info: { [vin]: { vehicle_command_protocol_required: false } } } },
+      });
+
+      const result = await service.checkTelemetryConfig(vin, 'test-user-id');
+
+      expect(result).toEqual({ ...mockConfig, vehicle_command_protocol_required: true });
+    });
+
     it('should catch error and return config if fleet_status fails when key_paired is false', async () => {
       const vin = 'VIN123';
       const mockConfig = { key_paired: false, fields: {} };

--- a/apps/api/src/app/telemetry/telemetry-config.service.ts
+++ b/apps/api/src/app/telemetry/telemetry-config.service.ts
@@ -261,7 +261,17 @@ export class TelemetryConfigService {
               headers: { Authorization: `Bearer ${accessToken}` },
             }
           );
-          telemetryConfig.vehicle_command_protocol_required = fleetStatusResponse.data.response.vehicle_info?.[vin]?.vehicle_command_protocol_required;
+          
+          let isRequired = fleetStatusResponse.data.response.vehicle_info?.[vin]?.vehicle_command_protocol_required;
+
+          // Tesla API fleet-status sometimes incorrectly returns false for Model 3/Y/Cybertruck,
+          // but these vehicles always require the vehicle command protocol.
+          const model = vin.charAt(3).toUpperCase();
+          if (['3', 'Y', 'C'].includes(model)) {
+            isRequired = true;
+          }
+
+          telemetryConfig.vehicle_command_protocol_required = isRequired;
         } catch (error: unknown) {
           this.logger.warn(`Failed to fetch fleet status for ${vin}: ${error}`);
         }


### PR DESCRIPTION
The Tesla API `fleet_status` endpoint occasionally reports `vehicle_command_protocol_required: false` for Model 3, Model Y, and Cybertruck, despite these models requiring the virtual key to be paired. This causes the UI to hide the 'Pair Virtual Key' button. This PR forces the flag to `true` for these vehicle models by inspecting the VIN, ensuring users are always prompted to pair their virtual keys and preventing downstream 502 errors when configuring telemetry.