### PR TITLE
fix(api): suppress break-in alerts on center display owner activity

### DIFF
--- a/apps/api/src/app/alerts/break-in/break-in-alert-handler.service.spec.ts
+++ b/apps/api/src/app/alerts/break-in/break-in-alert-handler.service.spec.ts
@@ -74,7 +74,7 @@ describe('The BreakInAlertHandlerService class', () => {
       });
     });
 
-    describe('When message contains a trunk opening DoorState event', () => {
+    describe('When message contains CenterDisplay owner activity', () => {
       let message: TelemetryMessage;
 
       beforeEach(() => {
@@ -83,29 +83,22 @@ describe('The BreakInAlertHandlerService class', () => {
         message.createdAt = new Date('2026-05-05T20:00:00Z').toISOString();
 
         const datum = new TelemetryDatum();
-        datum.key = 'DoorState';
+        datum.key = 'CenterDisplay';
         datum.value = new TelemetryValue();
-        datum.value.doorValue = {
-          DriverFront: false,
-          DriverRear: false,
-          PassengerFront: false,
-          PassengerRear: false,
-          TrunkFront: false,
-          TrunkRear: true,
-        };
+        datum.value.displayStateValue = 'DisplayStateAccessory';
         message.data = [datum];
 
         jest.spyOn(message, 'validateContainsCenterDisplay').mockReturnValue(false);
       });
 
-      it('should track the door opening event in the break-in event tracker', async () => {
+      it('should track the owner activity event in the break-in event tracker', async () => {
         await service.handle(message);
         const expectedTime = new Date(message.createdAt).getTime();
-        expect(mockEventTracker.track).toHaveBeenCalledWith('123', BreakInTrackedEvent.DoorOpened, expectedTime);
+        expect(mockEventTracker.track).toHaveBeenCalledWith('123', BreakInTrackedEvent.CenterDisplayOwnerActivity, expectedTime);
       });
     });
 
-    describe('When message contains a passenger door opening DoorState event', () => {
+    describe('When message contains CenterDisplay Off state', () => {
       let message: TelemetryMessage;
 
       beforeEach(() => {
@@ -114,75 +107,15 @@ describe('The BreakInAlertHandlerService class', () => {
         message.createdAt = new Date('2026-05-05T20:00:00Z').toISOString();
 
         const datum = new TelemetryDatum();
-        datum.key = 'DoorState';
+        datum.key = 'CenterDisplay';
         datum.value = new TelemetryValue();
-        datum.value.doorValue = {
-          DriverFront: false,
-          DriverRear: false,
-          PassengerFront: false,
-          PassengerRear: true,
-          TrunkFront: false,
-          TrunkRear: false,
-        };
+        datum.value.displayStateValue = 'DisplayStateOff';
         message.data = [datum];
 
         jest.spyOn(message, 'validateContainsCenterDisplay').mockReturnValue(false);
       });
 
-      it('should track the door opening event in the break-in event tracker', async () => {
-        await service.handle(message);
-        const expectedTime = new Date(message.createdAt).getTime();
-        expect(mockEventTracker.track).toHaveBeenCalledWith('123', BreakInTrackedEvent.DoorOpened, expectedTime);
-      });
-    });
-
-    describe('When message contains a DoorState event with all doors closed', () => {
-      let message: TelemetryMessage;
-
-      beforeEach(() => {
-        message = new TelemetryMessage();
-        message.vin = '123';
-        message.createdAt = new Date('2026-05-05T20:00:00Z').toISOString();
-
-        const datum = new TelemetryDatum();
-        datum.key = 'DoorState';
-        datum.value = new TelemetryValue();
-        datum.value.doorValue = {
-          DriverFront: false,
-          DriverRear: false,
-          PassengerFront: false,
-          PassengerRear: false,
-          TrunkFront: false,
-          TrunkRear: false,
-        };
-        message.data = [datum];
-
-        jest.spyOn(message, 'validateContainsCenterDisplay').mockReturnValue(false);
-      });
-
-      it('should not track any event in the break-in event tracker', async () => {
-        await service.handle(message);
-        expect(mockEventTracker.track).not.toHaveBeenCalled();
-      });
-    });
-
-    describe('When message contains a DoorState event without any open door value', () => {
-      let message: TelemetryMessage;
-
-      beforeEach(() => {
-        message = new TelemetryMessage();
-        message.vin = '123';
-        message.createdAt = new Date('2026-05-05T20:00:00Z').toISOString();
-
-        const datum = new TelemetryDatum();
-        datum.key = 'DoorState';
-        datum.value = new TelemetryValue();
-        message.data = [datum];
-
-        jest.spyOn(message, 'validateContainsCenterDisplay').mockReturnValue(false);
-      });
-
-      it('should not track any event in the break-in event tracker', async () => {
+      it('should not track owner activity in the break-in event tracker', async () => {
         await service.handle(message);
         expect(mockEventTracker.track).not.toHaveBeenCalled();
       });
@@ -249,7 +182,7 @@ describe('The BreakInAlertHandlerService class', () => {
       });
     });
 
-    describe('When displayState is DisplayStateLock and a door opening occurred within the grace period', () => {
+    describe('When displayState is DisplayStateLock and owner activity occurred within the grace period', () => {
       let message: TelemetryMessage;
 
       beforeEach(() => {
@@ -259,8 +192,8 @@ describe('The BreakInAlertHandlerService class', () => {
         message.data = [];
         jest.spyOn(message, 'validateContainsCenterDisplay').mockReturnValue(true);
         jest.spyOn(message, 'isCenterDisplayLocked').mockReturnValue(true);
-        mockEventTracker.hasEventAround.mockImplementation((_vin, event) =>
-          event === BreakInTrackedEvent.DoorOpened
+        mockEventTracker.hasEventAfter.mockImplementation((_vin, event) =>
+          event === BreakInTrackedEvent.CenterDisplayOwnerActivity
         );
       });
 

--- a/apps/api/src/app/alerts/break-in/break-in-alert-handler.service.ts
+++ b/apps/api/src/app/alerts/break-in/break-in-alert-handler.service.ts
@@ -45,8 +45,8 @@ export class BreakInAlertHandlerService implements TelemetryEventHandler {
       this.eventTracker.track(telemetryMessage.vin, BreakInTrackedEvent.ChargePortLatchDisengaged, eventTime);
     }
 
-    if (telemetryMessage.extractOpenDoors().length > 0) {
-      this.eventTracker.track(telemetryMessage.vin, BreakInTrackedEvent.DoorOpened, eventTime);
+    if (telemetryMessage.isCenterDisplayOwnerActivity()) {
+      this.eventTracker.track(telemetryMessage.vin, BreakInTrackedEvent.CenterDisplayOwnerActivity, eventTime);
     }
   }
 
@@ -97,8 +97,8 @@ export class BreakInAlertHandlerService implements TelemetryEventHandler {
         return;
       }
 
-      if (this.eventTracker.hasEventAround(telemetryMessage.vin, BreakInTrackedEvent.DoorOpened, eventTime)) {
-        this.logger.log(`[False Positive Prevented] Suppressing break-in alert for VIN ${telemetryMessage.vin} due to door/trunk opening within the grace period.`);
+      if (this.eventTracker.hasEventAfter(telemetryMessage.vin, BreakInTrackedEvent.CenterDisplayOwnerActivity, eventTime)) {
+        this.logger.log(`[False Positive Prevented] Suppressing break-in alert for VIN ${telemetryMessage.vin} due to correlated CenterDisplay owner activity.`);
         return;
       }
 

--- a/apps/api/src/app/alerts/break-in/break-in-event-tracker.service.spec.ts
+++ b/apps/api/src/app/alerts/break-in/break-in-event-tracker.service.spec.ts
@@ -38,33 +38,43 @@ describe('The BreakInEventTrackerService class', () => {
     });
   });
 
-  describe('The track() and hasEventAround() methods for DoorOpened', () => {
-    describe('When tracking a door opening event', () => {
+  describe('The track() and CenterDisplayOwnerActivity query methods', () => {
+    describe('When tracking CenterDisplay owner activity', () => {
       beforeEach(() => {
-        service.track(fakeVin, BreakInTrackedEvent.DoorOpened, baseTimestamp);
+        service.track(fakeVin, BreakInTrackedEvent.CenterDisplayOwnerActivity, baseTimestamp);
       });
 
       it('should store the event timestamp and make it available for checking', () => {
-        const hasEvent = service.hasEventAround(fakeVin, BreakInTrackedEvent.DoorOpened, baseTimestamp);
+        const hasEvent = service.hasEventAround(fakeVin, BreakInTrackedEvent.CenterDisplayOwnerActivity, baseTimestamp);
         expect(hasEvent).toStrictEqual(true);
       });
 
-      it('should return true when the event is within 4000ms of the checked timestamp', () => {
-        const hasEvent = service.hasEventAround(fakeVin, BreakInTrackedEvent.DoorOpened, baseTimestamp + 3900);
+      it('should return true when the event is within 5000ms of the checked timestamp', () => {
+        const hasEvent = service.hasEventAround(fakeVin, BreakInTrackedEvent.CenterDisplayOwnerActivity, baseTimestamp + 4900);
         expect(hasEvent).toStrictEqual(true);
       });
 
-      it('should return false when the event is outside 4000ms of the checked timestamp', () => {
-        const hasEvent = service.hasEventAround(fakeVin, BreakInTrackedEvent.DoorOpened, baseTimestamp + 4100);
+      it('should return false when the event is outside 5000ms of the checked timestamp', () => {
+        const hasEvent = service.hasEventAround(fakeVin, BreakInTrackedEvent.CenterDisplayOwnerActivity, baseTimestamp + 5100);
+        expect(hasEvent).toStrictEqual(false);
+      });
+
+      it('should return true when the event occurs after the checked timestamp within 5000ms', () => {
+        const hasEvent = service.hasEventAfter(fakeVin, BreakInTrackedEvent.CenterDisplayOwnerActivity, baseTimestamp - 4900);
+        expect(hasEvent).toStrictEqual(true);
+      });
+
+      it('should return false when the event occurs before the checked timestamp', () => {
+        const hasEvent = service.hasEventAfter(fakeVin, BreakInTrackedEvent.CenterDisplayOwnerActivity, baseTimestamp + 1);
         expect(hasEvent).toStrictEqual(false);
       });
     });
   });
 
   describe('The event type isolation', () => {
-    describe('When only a door opening event was tracked', () => {
+    describe('When only CenterDisplay owner activity was tracked', () => {
       beforeEach(() => {
-        service.track(fakeVin, BreakInTrackedEvent.DoorOpened, baseTimestamp);
+        service.track(fakeVin, BreakInTrackedEvent.CenterDisplayOwnerActivity, baseTimestamp);
       });
 
       it('should not report a latch event', () => {
@@ -78,19 +88,19 @@ describe('The BreakInEventTrackerService class', () => {
         service.track(fakeVin, BreakInTrackedEvent.ChargePortLatchDisengaged, baseTimestamp);
       });
 
-      it('should not report a door opening event', () => {
-        const hasEvent = service.hasEventAround(fakeVin, BreakInTrackedEvent.DoorOpened, baseTimestamp);
+      it('should not report CenterDisplay owner activity', () => {
+        const hasEvent = service.hasEventAround(fakeVin, BreakInTrackedEvent.CenterDisplayOwnerActivity, baseTimestamp);
         expect(hasEvent).toStrictEqual(false);
       });
     });
 
     describe('When events are tracked for different VINs', () => {
       beforeEach(() => {
-        service.track(fakeVin, BreakInTrackedEvent.DoorOpened, baseTimestamp);
+        service.track(fakeVin, BreakInTrackedEvent.CenterDisplayOwnerActivity, baseTimestamp);
       });
 
       it('should not report the event for another VIN', () => {
-        const hasEvent = service.hasEventAround('other-vin', BreakInTrackedEvent.DoorOpened, baseTimestamp);
+        const hasEvent = service.hasEventAround('other-vin', BreakInTrackedEvent.CenterDisplayOwnerActivity, baseTimestamp);
         expect(hasEvent).toStrictEqual(false);
       });
     });

--- a/apps/api/src/app/alerts/break-in/break-in-event-tracker.service.ts
+++ b/apps/api/src/app/alerts/break-in/break-in-event-tracker.service.ts
@@ -2,12 +2,12 @@ import { Injectable } from '@nestjs/common';
 
 export enum BreakInTrackedEvent {
   ChargePortLatchDisengaged = 'ChargePortLatchDisengaged',
-  DoorOpened = 'DoorOpened',
+  CenterDisplayOwnerActivity = 'CenterDisplayOwnerActivity',
 }
 
 const EVENT_TRACKING_CONFIG: Record<BreakInTrackedEvent, { windowMs: number; cleanupMs: number }> = {
   [BreakInTrackedEvent.ChargePortLatchDisengaged]: { windowMs: 5000, cleanupMs: 15000 },
-  [BreakInTrackedEvent.DoorOpened]: { windowMs: 4000, cleanupMs: 12000 },
+  [BreakInTrackedEvent.CenterDisplayOwnerActivity]: { windowMs: 5000, cleanupMs: 15000 },
 };
 
 @Injectable()
@@ -28,8 +28,18 @@ export class BreakInEventTrackerService {
 
     const hasEvent = events.some(t => Math.abs(eventTimestamp - t) <= windowMs);
 
-    const now = Date.now();
-    this.setEvents(vin, event, events.filter(t => now - t < cleanupMs));
+    this.cleanup(vin, event, events, cleanupMs);
+
+    return hasEvent;
+  }
+
+  public hasEventAfter(vin: string, event: BreakInTrackedEvent, eventTimestamp: number): boolean {
+    const { windowMs, cleanupMs } = EVENT_TRACKING_CONFIG[event];
+    const events = this.getEvents(vin, event);
+
+    const hasEvent = events.some(t => t >= eventTimestamp && t - eventTimestamp <= windowMs);
+
+    this.cleanup(vin, event, events, cleanupMs);
 
     return hasEvent;
   }
@@ -42,5 +52,10 @@ export class BreakInEventTrackerService {
     const vinEvents = this.recentEvents.get(vin) || new Map<BreakInTrackedEvent, number[]>();
     vinEvents.set(event, events);
     this.recentEvents.set(vin, vinEvents);
+  }
+
+  private cleanup(vin: string, event: BreakInTrackedEvent, events: number[], cleanupMs: number): void {
+    const now = Date.now();
+    this.setEvents(vin, event, events.filter(t => now - t < cleanupMs));
   }
 }

--- a/apps/api/src/app/telemetry/break-in-monitoring-config.service.spec.ts
+++ b/apps/api/src/app/telemetry/break-in-monitoring-config.service.spec.ts
@@ -74,7 +74,6 @@ describe('The BreakInMonitoringConfigService class', () => {
           {
             CenterDisplay: { interval_seconds: expectedInterval },
             ChargePortLatch: { interval_seconds: expectedInterval },
-            DoorState: { interval_seconds: expectedInterval }
           },
           []
         );
@@ -100,7 +99,7 @@ describe('The BreakInMonitoringConfigService class', () => {
           vin,
           userId,
           {},
-          ['CenterDisplay', 'ChargePortLatch', 'DoorState']
+          ['CenterDisplay', 'ChargePortLatch']
         );
         expect(vehicle.break_in_monitoring_enabled).toBe(false);
         expect(mockVehicleRepository.save).toHaveBeenCalledWith(vehicle);

--- a/apps/api/src/app/telemetry/break-in-monitoring-config.service.ts
+++ b/apps/api/src/app/telemetry/break-in-monitoring-config.service.ts
@@ -13,7 +13,7 @@ import { Vehicle } from '../../entities/vehicle.entity';
 import { TELEMETRY_CONFIG } from './telemetry-config.constants';
 import { extractErrorDetails } from './telemetry-config.helpers';
 
-const BREAK_IN_MONITORED_FIELDS = ['CenterDisplay', 'ChargePortLatch', 'DoorState'];
+const BREAK_IN_MONITORED_FIELDS = ['CenterDisplay', 'ChargePortLatch'];
 
 export interface BreakInMonitoringToggleResult {
   success: true;

--- a/apps/api/src/app/telemetry/models/telemetry-message.model.spec.ts
+++ b/apps/api/src/app/telemetry/models/telemetry-message.model.spec.ts
@@ -270,6 +270,28 @@ describe('TelemetryMessage Model', () => {
 
       expect(message.isCenterDisplayLocked()).toBe(false);
     });
+
+    it.each(['DisplayStateAccessory', 'DisplayStateOn', 'DisplayStateDriving'])('should return true for owner activity state %s', (state) => {
+      const message = plainToClass(TelemetryMessage, {
+        data: [{ key: 'CenterDisplay', value: { displayStateValue: state } }],
+        createdAt: '2025-11-26T16:57:07.330713028Z',
+        vin: '123',
+        isResend: false
+      });
+
+      expect(message.isCenterDisplayOwnerActivity()).toBe(true);
+    });
+
+    it('should return false for DisplayStateOff owner activity state', () => {
+      const message = plainToClass(TelemetryMessage, {
+        data: [{ key: 'CenterDisplay', value: { displayStateValue: 'DisplayStateOff' } }],
+        createdAt: '2025-11-26T16:57:07.330713028Z',
+        vin: '123',
+        isResend: false
+      });
+
+      expect(message.isCenterDisplayOwnerActivity()).toBe(false);
+    });
   });
 
   describe('DoorState methods', () => {

--- a/apps/api/src/app/telemetry/models/telemetry-message.model.ts
+++ b/apps/api/src/app/telemetry/models/telemetry-message.model.ts
@@ -25,6 +25,15 @@ const STRING_TO_SENTRY_MODE_MAP: Record<string, SentryModeState> = {
   'Unknown': SentryModeState.Unknown,
 };
 
+const CENTER_DISPLAY_OWNER_ACTIVITY_STATES = new Set([
+  'DisplayStateAccessory',
+  'Accessory',
+  'DisplayStateOn',
+  'On',
+  'DisplayStateDriving',
+  'Driving',
+]);
+
 export class TelemetryValue {
   @IsOptional()
   @IsString()
@@ -139,6 +148,15 @@ export class TelemetryMessage {
     const { displayStateValue, stringValue } = displayDatum.value;
     const value = displayStateValue ?? stringValue;
     return value === 'DisplayStateLock' || value === 'Lock';
+  }
+
+  isCenterDisplayOwnerActivity(): boolean {
+    const displayDatum = this.data.find(d => d.key === 'CenterDisplay');
+    if (!displayDatum) return false;
+
+    const { displayStateValue, stringValue } = displayDatum.value;
+    const value = displayStateValue ?? stringValue;
+    return value !== undefined && CENTER_DISPLAY_OWNER_ACTIVITY_STATES.has(value);
   }
 
   extractOpenDoors(): string[] {


### PR DESCRIPTION
## Problem

Break-in alerts are dispatched on every `CenterDisplay=Lock` telemetry event unless a correlated door/trunk opening or charge-port latch event is seen within a very short grace window around the lock event.

In practice this produces a high volume of false positives: when the owner approaches the vehicle, the display unlock and door opening typically happen several seconds after the last `Lock` sample, far outside the grace window. Each dispatched false alert can then trigger offensive responses (honk/boombox) on users' vehicles.

Subscribing every vehicle to `DoorState` telemetry just to catch these owner approaches also adds a significant volume of telemetry events fleet-wide.

## Solution

Replace the `DoorState`-based suppression with a `CenterDisplay` state rule that requires no additional telemetry:

- **`Lock → Accessory / On / Driving`** within 5s after the lock event → treated as owner activity, break-in alert suppressed.
- **`Lock → Off`** → remains suspicious, no suppression.
- **`ChargePortLatchDisengaged`** correlation kept unchanged.
- Break-in monitoring now only subscribes `CenterDisplay` + `ChargePortLatch`; `DoorState` is removed from the fields pushed to Tesla fleet telemetry.

Notification latency is unchanged (verification still runs after `BREAK_IN_ALERT_CHECK_DELAY_MS`).

> Note: vehicle telemetry configs created before this change may still include `DoorState`. Cleanup of existing configs is handled separately by an ops script, not in this PR.
